### PR TITLE
:lipstick: Fix font-family, Add color on selection

### DIFF
--- a/htdocs/luci-static/argon/css/style.css
+++ b/htdocs/luci-static/argon/css/style.css
@@ -1578,7 +1578,7 @@ div > .table > .tbody > .tr:nth-of-type(2n) {
 .main > .main-left > .sidenav-header > .brand {
     font-size: 1.8rem;
     color: #5e72e4;
-    font-family: "TypoGraphica";
+    font-family: "TypoGraphica", sans-serif;
     text-decoration: none;
     padding-left: 2rem;
     cursor: default;

--- a/htdocs/luci-static/argon/css/style.css
+++ b/htdocs/luci-static/argon/css/style.css
@@ -195,7 +195,7 @@ html, body {
     margin: 0px;
     padding: 0px;
     height: 100%;
-    font-family: Open Sans,sans-serif Microsoft Yahei, WenQuanYi Micro Hei, sans-serif, "Helvetica Neue", Helvetica, Hiragino Sans GB;
+    font-family: Open Sans, Microsoft Yahei, WenQuanYi Micro Hei, "Helvetica Neue", Helvetica, Hiragino Sans GB, sans-serif;
 }
 
 /*** Main Loading ***/

--- a/htdocs/luci-static/argon/css/style.css
+++ b/htdocs/luci-static/argon/css/style.css
@@ -68,7 +68,10 @@
     --font-family-monospace: SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace;
 }
 
-
+::selection {
+    background-color: var(--primary);
+    color: #ffffff;
+}
 
 @font-face {
     font-family: 'icomoon';


### PR DESCRIPTION
Serif is rendered as font-family (tested on Windows / MacOs with Firefox and Chrome). This commit fixes the fonts fallback and font families