### PR TITLE
fix abbr text invisible

### DIFF
--- a/htdocs/luci-static/argon/cascade.css
+++ b/htdocs/luci-static/argon/cascade.css
@@ -398,7 +398,7 @@ code {
 abbr {
   cursor: help;
   text-decoration: underline;
-  color: #fff;
+  color: #797474;
 }
 hr {
   margin: 1rem 0;

--- a/htdocs/luci-static/argon/cascade.less
+++ b/htdocs/luci-static/argon/cascade.less
@@ -466,7 +466,7 @@ code {
 abbr {
     cursor: help;
     text-decoration: underline;
-    color: #fff;
+    color: #797474;
 }
 
 hr {


### PR DESCRIPTION
带提示文字，白底白字，看不见啊，就好像文字丢失一样。
black mod的还好，可这个不是，所以换个颜色，这个颜色就算是黑底也能用。

示例：网络--接口--an--物理设置--开启   - [ ] 。（是不是少了几个字）
