### PR TITLE
Update dark.css

### DIFF
--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -240,7 +240,7 @@ h4 {
   background-color: #1e1e1f;
 }
 .cbi-button {
-  color: #ccc !important;
+  color: #ccc;
   background-color: #483d8b;
   background-color: var(--dark-primary);
 }


### PR DESCRIPTION
移除暗黑模式下.cbi-button中color属性的!important标记, 保持按钮文字颜色正常的同时兼容修复.cbi-button-up和.cbi-button-down按钮的显示异常问题.

详见 #224 