### PR TITLE
update bing wallpaper url

### DIFF
--- a/luasrc/view/themes/argon/sysauth.htm
+++ b/luasrc/view/themes/argon/sysauth.htm
@@ -62,7 +62,7 @@
 	end
 
 	local boardinfo			= util.ubus("system", "board")
-	local bingUrl 			= "http://www.bing.com/"
+	local bingUrl 			= "http://www4.bing.com/"
 	local bingApiUrl 		= bingUrl .. "HPImageArchive.aspx?format=js&idx=0&n=1&mkt=en-US"
 	local themeDir			= media .. "/background/"
 	local bgUrl 			= media .. "/img/bg1.jpg"


### PR DESCRIPTION
www.bing.com 目前国内暂时无法直连，而 [www4.bing.com](www4.bing.com) 可以