### PR TITLE
18.06

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
 LUCI_DEPENDS:=+curl +jsonfilter
-PKG_VERSION:=1.7.3
-PKG_RELEASE:=20220421
+PKG_VERSION:=1.7.4
+PKG_RELEASE:=20230321
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
-LUCI_DEPENDS:=
+LUCI_DEPENDS:=+curl +jsonfilter
 PKG_VERSION:=1.7.3
 PKG_RELEASE:=20220421
 

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -18,7 +18,7 @@
  *  luci-theme-material:
  *      https://github.com/LuttyYang/luci-theme-material/
  *
- *  Agron Theme
+ *  Argon Theme
  *	    https://demos.creative-tim.com/argon-dashboard/index.html
  *
  *  Login background

--- a/htdocs/luci-static/argon/css/fonts.css
+++ b/htdocs/luci-static/argon/css/fonts.css
@@ -18,7 +18,7 @@
  *  luci-theme-material:
  *      https://github.com/LuttyYang/luci-theme-material/
  *
- *  Agron Theme
+ *  Argon Theme
  *	    https://demos.creative-tim.com/argon-dashboard/index.html
  *
  *  Login background

--- a/htdocs/luci-static/argon/js/script.js
+++ b/htdocs/luci-static/argon/js/script.js
@@ -18,7 +18,7 @@
  *  luci-theme-material:
  *      https://github.com/LuttyYang/luci-theme-material/
  *
- *  Agron Theme
+ *  Argon Theme
  *	    https://demos.creative-tim.com/argon-dashboard/index.html
  *
  *  Login background
@@ -124,6 +124,9 @@
 
 // define what element should be observed by the observer
 // and what types of mutations trigger the callback
+    const observer = new MutationObserver(() => {
+    console.log("callback that runs when observer is triggered");
+    });
     if ($("#cbi-dhcp-lan-ignore").length > 0) {
         observer.observe(document.getElementById("cbi-dhcp-lan-ignore"), {
             subtree: true,
@@ -166,6 +169,11 @@
     /**
      * get current node and open it
      */
+    if (getCurrentNodeByUrl()) {
+        mainNodeName = "node-" + luciLocation[0] + "-" + luciLocation[1];
+        mainNodeName = mainNodeName.replace(/[ \t\n\r\/]+/g, "_").toLowerCase();
+        $("body").addClass(mainNodeName);
+    }
     
     $(".cbi-button-up").val("");
     $(".cbi-button-down").val("");

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -19,7 +19,7 @@
  *  luci-theme-material:
  *      https://github.com/LuttyYang/luci-theme-material/
  *
- *  Agron Theme
+ *  Argon Theme
  *	    https://demos.creative-tim.com/argon-dashboard/index.html
  *
  *  Login background

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -19,7 +19,7 @@
  *  luci-theme-material:
  *      https://github.com/LuttyYang/luci-theme-material/
  *
- *  Agron Theme
+ *  Argon Theme
  *	    https://demos.creative-tim.com/argon-dashboard/index.html
  *
  *  Login background

--- a/luasrc/view/themes/argon/footer.htm
+++ b/luasrc/view/themes/argon/footer.htm
@@ -18,7 +18,7 @@
 	luci-theme-material:
 	https://github.com/LuttyYang/luci-theme-material/
 
-	Agron Theme
+	Argon Theme
 	https://demos.creative-tim.com/argon-dashboard/index.html
 
 	Login background

--- a/luasrc/view/themes/argon/header.htm
+++ b/luasrc/view/themes/argon/header.htm
@@ -15,7 +15,7 @@
 	MUI:
 	https://github.com/muicss/mui
 	
-	Agron Theme
+	Argon Theme
 	https://demos.creative-tim.com/argon-dashboard/index.html
 
 	Licensed to the public under the Apache License 2.0
@@ -44,7 +44,7 @@
 	local node = disp.context.dispatched
 
 	local categories = disp.node_childs(tree)
-	local currentNode = luci.dispatcher.context.path
+
 	local c = tree
 	local i, r
 	
@@ -108,22 +108,16 @@
 		end
 	end
 
-	local function render_submenu(prefix,parent, node)
+	local function render_submenu(prefix, node)
 		local childs = disp.node_childs(node)
 		if #childs > 0 then
-			local active = (currentNode[2] == parent) and "active" or ""
-			local display = (currentNode[2] == parent) and 'style="display: block;"' or ""
-			
-			write('<ul class="slide-menu %s" %s>' %{
-				active,
-				display
-			})
+			write('<ul class="slide-menu">')
+
 			for i, r in ipairs(childs) do
 				local nnode = node.nodes[r]
 				local title = pcdata(striptags(translate(nnode.title)))
-				local subactive = (currentNode[3] == r) and 'class="active"' or ""
-				write('<li %s><a data-title="%s" href="%s">%s</a></li>' %{
-					subactive,
+
+				write('<li><a data-title="%s" href="%s">%s</a></li>' %{
 					title,
 					nodeurl(prefix, r, nnode.query),
 					title
@@ -138,21 +132,20 @@
 		local childs = disp.node_childs(cattree)
 		if #childs > 0 then
 			write('<ul class="nav">')
-			
+
 			for i, r in ipairs(childs) do
 				local nnode = cattree.nodes[r]
 				local grandchildren = disp.node_childs(nnode)
+
 				if #grandchildren > 0 then
-					local active = (currentNode[2] == r) and "active" or ""
 					local title = pcdata(striptags(translate(nnode.title)))
                                         local en_title = pcdata(striptags(string.gsub(nnode.title," ","_")))
-					write('<li class="slide"><a class="menu %s" data-title="%s" href="#">%s</a>' %{
-						active,
+					write('<li class="slide"><a class="menu" data-title="%s" href="#">%s</a>' %{
 						en_title,
 						title
 					})
 
-					render_submenu(category .. "/" .. r,r, nnode)
+					render_submenu(category .. "/" .. r, nnode)
 					write('</li>')
 				else
 					local title = pcdata(striptags(translate(nnode.title)))

--- a/luasrc/view/themes/argon/header_login.htm
+++ b/luasrc/view/themes/argon/header_login.htm
@@ -15,7 +15,7 @@
 	MUI:
 	https://github.com/muicss/mui
 	
-	Agron Theme
+	Argon Theme
 	https://demos.creative-tim.com/argon-dashboard/index.html
 
 	Licensed to the public under the Apache License 2.0

--- a/luasrc/view/themes/argon/sysauth.htm
+++ b/luasrc/view/themes/argon/sysauth.htm
@@ -15,7 +15,7 @@
 	MUI:
 	https://github.com/muicss/mui
 	
-	Agron Theme
+	Argon Theme
 	https://demos.creative-tim.com/argon-dashboard/index.html
 
 	Licensed to the public under the Apache License 2.0
@@ -61,8 +61,6 @@
 	end
 
 	local boardinfo			= util.ubus("system", "board")
-	local bingUrl 			= "http://www.bing.com/"
-	local bingApiUrl 		= bingUrl .. "HPImageArchive.aspx?format=js&idx=0&n=1&mkt=en-US"
 	local themeDir			= media .. "/background/"
 	local bgUrl 			= media .. "/img/bg1.jpg"
 	local useBing			= fs.access('/etc/config/argon') and uci:get_first('argon', 'global', 'bing_background') or "0"
@@ -70,9 +68,9 @@
 	local backgroundType 	= "Image"
 
 	function getBing()
-		local bing = sys.exec("wget --timeout=0.5 -qO- '%s'" %bingApiUrl)
+		local bing = sys.exec("/usr/libexec/argon/bing_wallpaper")
 		if (bing and bing ~= '') then
-			bgUrl 	= bingUrl .. json.parse(bing).images[1].url
+			bgUrl 	= bing
 		end
 	end
 

--- a/root/usr/libexec/argon/bing_wallpaper
+++ b/root/usr/libexec/argon/bing_wallpaper
@@ -1,0 +1,52 @@
+#!/bin/sh
+# author jjm2473
+
+BING_BASE=http://www.bing.com
+CACHE=/var/run/argon_bing.url
+WRLOCK=/var/lock/argon_bing.lock
+
+fetch_url_path() {
+    curl --fail --show-error --max-time 1 \
+        "$BING_BASE/HPImageArchive.aspx?format=js&idx=0&n=1&mkt=en-US" 2>/dev/null \
+        | jsonfilter -q -e '@.images[0].url'
+}
+
+try_update() {
+    local lock="$WRLOCK"
+    exec 200>$lock
+
+    if flock -n 200 >/dev/null 2>&1; then
+        local path=`fetch_url_path`
+        if [ -n "$path" ]; then
+            echo "${BING_BASE}${path}" | tee "$CACHE"
+        else
+            if [ -s "$CACHE" ]; then
+                cat "$CACHE"
+            else
+                touch "$CACHE"
+            fi
+        fi
+        flock -u 200 >/dev/null 2>&1
+    elif [ -s "$CACHE" ]; then
+        cat "$CACHE"
+    fi
+}
+
+get_url() {
+    if [ -f "$CACHE" ]; then
+        local idle_t=$((`date '+%s'` - `date -r "$CACHE" '+%s' 2>/dev/null || echo '0'`))
+        if [ -s "$CACHE" ]; then
+            if [ $idle_t -le 43200 ]; then
+                cat "$CACHE"
+                return
+            fi
+        else
+            if [ $idle_t -le 120 ]; then
+                return
+            fi
+        fi
+    fi
+    try_update
+}
+
+get_url


### PR DESCRIPTION
1.修复输入错误
2.修复菜单自动折叠(回退1.7.2)
3.修复某些界面,如:接口-LAN的设置中的" 一般配置&DHCP 服务器"的<legend>标签不显示
4.合并master https://github.com/jerrykuku/luci-theme-argon/pull/310 @jjm2473 : 修改必应壁纸更新逻辑，防止wget卡死导致登录界面加载失败，新的逻辑使用curl，并且加锁，就算卡死以后再次刷新界面会跳过必应壁纸的流程
5.更新依赖