### PR TITLE
18.06 添加webp格式图片支持，修复一些bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
 LUCI_DEPENDS:=+curl +jsonfilter
-PKG_VERSION:=1.7.4
-PKG_RELEASE:=20230321
+PKG_VERSION:=1.7.5
+PKG_RELEASE:=20230322
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1787,6 +1787,10 @@ width:100%
 .cbi-section-table-row>.cbi-value-field .cbi-input-password{
 min-width:100px
 }
+.cbi-section-table-row.cbi-rowstyle-1 div,
+.cbi-section-table-row.cbi-rowstyle-2 div{
+min-width:100%;
+}
 .cbi-section-table-row > .cbi-value-field [data-dynlist] > input,
 .cbi-section-table-row > .cbi-value-field input.cbi-input-password {
   width: calc(100% - 1.5rem);

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1777,11 +1777,15 @@ table > thead > tr > th,
 .cbi-section-table-row:last-child {
   margin-bottom: 0;
 }
-.cbi-section-table-row > .cbi-value-field .cbi-input-select,
-.cbi-section-table-row > .cbi-value-field .cbi-input-text,
-.cbi-section-table-row > .cbi-value-field .cbi-input-password,
-.cbi-section-table-row > .cbi-value-field .cbi-dropdown {
-  width: 100%;
+.cbi-section-table-row>.cbi-value-field .cbi-dropdown,
+.cbi-section-table-row>.cbi-value-field .cbi-input-select,
+.cbi-section-table-row>.cbi-value-field .cbi-input-text,
+.cbi-section-table-row>.cbi-value-field .cbi-input-password{
+width:100%
+}
+.cbi-section-table-row>.cbi-value-field .cbi-input-text,
+.cbi-section-table-row>.cbi-value-field .cbi-input-password{
+min-width:100px
 }
 .cbi-section-table-row > .cbi-value-field [data-dynlist] > input,
 .cbi-section-table-row > .cbi-value-field input.cbi-input-password {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1781,15 +1781,15 @@ table > thead > tr > th,
 .cbi-section-table-row>.cbi-value-field .cbi-input-select,
 .cbi-section-table-row>.cbi-value-field .cbi-input-text,
 .cbi-section-table-row>.cbi-value-field .cbi-input-password{
-width:100%
+  width:100%
 }
 .cbi-section-table-row>.cbi-value-field .cbi-input-text,
 .cbi-section-table-row>.cbi-value-field .cbi-input-password{
-min-width:100px
+  min-width:100px
 }
-.cbi-section-table-row.cbi-rowstyle-1 div,
-.cbi-section-table-row.cbi-rowstyle-2 div{
-min-width:100%;
+#lease6_status_table > tbody > .cbi-section-table-row.cbi-rowstyle-1 div,
+#lease6_status_table > tbody > .cbi-section-table-row.cbi-rowstyle-2 div{
+  min-width:100%;
 }
 .cbi-section-table-row > .cbi-value-field [data-dynlist] > input,
 .cbi-section-table-row > .cbi-value-field input.cbi-input-password {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2165,11 +2165,16 @@ table>thead>tr>th,
     margin-bottom: 0;
 }
 
+.cbi-section-table-row>.cbi-value-field .cbi-dropdown,
 .cbi-section-table-row>.cbi-value-field .cbi-input-select,
 .cbi-section-table-row>.cbi-value-field .cbi-input-text,
-.cbi-section-table-row>.cbi-value-field .cbi-input-password,
-.cbi-section-table-row>.cbi-value-field .cbi-dropdown {
-    width: 100%;
+.cbi-section-table-row>.cbi-value-field .cbi-input-password{
+width:100%
+}
+
+.cbi-section-table-row>.cbi-value-field .cbi-input-text,
+.cbi-section-table-row>.cbi-value-field .cbi-input-password{
+min-width:100px
 }
 
 .cbi-section-table-row>.cbi-value-field [data-dynlist]>input,

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2177,6 +2177,11 @@ width:100%
 min-width:100px
 }
 
+.cbi-section-table-row.cbi-rowstyle-1 div,
+.cbi-section-table-row.cbi-rowstyle-2 div{
+min-width:100%;
+}
+
 .cbi-section-table-row>.cbi-value-field [data-dynlist]>input,
 .cbi-section-table-row>.cbi-value-field input.cbi-input-password {
     width: calc(100% - 1.5rem);

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2169,17 +2169,17 @@ table>thead>tr>th,
 .cbi-section-table-row>.cbi-value-field .cbi-input-select,
 .cbi-section-table-row>.cbi-value-field .cbi-input-text,
 .cbi-section-table-row>.cbi-value-field .cbi-input-password{
-width:100%
+    width:100%
 }
 
 .cbi-section-table-row>.cbi-value-field .cbi-input-text,
 .cbi-section-table-row>.cbi-value-field .cbi-input-password{
-min-width:100px
+    min-width:100px
 }
 
-.cbi-section-table-row.cbi-rowstyle-1 div,
-.cbi-section-table-row.cbi-rowstyle-2 div{
-min-width:100%;
+#lease6_status_table > tbody > .cbi-section-table-row.cbi-rowstyle-1 div,
+#lease6_status_table > tbody > .cbi-section-table-row.cbi-rowstyle-2 div{
+    min-width:100%;
 }
 
 .cbi-section-table-row>.cbi-value-field [data-dynlist]>input,

--- a/luasrc/view/themes/argon/sysauth.htm
+++ b/luasrc/view/themes/argon/sysauth.htm
@@ -14,7 +14,7 @@
 
 	MUI:
 	https://github.com/muicss/mui
-	
+
 	Argon Theme
 	https://demos.creative-tim.com/argon-dashboard/index.html
 
@@ -29,10 +29,10 @@
 	local sys 	= require "luci.sys"
 	local json 	= require "luci.jsonc"
 	local uci 	= require 'luci.model.uci'.cursor()
-	
-	-- Fetch Local Background Media
 
-	function glob(...)
+	-- Fetch Local Background Media
+	
+	local function glob(...)
 		local iter, code, msg = fs.glob(...)
 		if iter then
 			return nutil.consume(iter)
@@ -41,14 +41,21 @@
 		end
 	end
 
-	function fetchMedia(path,themeDir)
+
+	local imageTypes = " jpg png gif webp "
+	local videoTypes = " mp4 webm "
+	local allTypes = imageTypes .. videoTypes
+	local function fetchMedia(path,themeDir)
 		local backgroundTable 	= {}
 		local backgroundCount 	= 0
 		for i, f in ipairs(glob(path)) do
 			attr = fs.stat(f)
 			if attr then
 				local ext = fs.basename(f):match(".+%.(%w+)$")
-				if ext == "jpg" or ext == "png" or ext == "gif" or ext == "mp4" then
+				if ext ~= nil then
+					ext = ext:lower()
+				end
+				if ext ~= nil and string.match(allTypes, " "..ext.." ") ~= nil then
 					local bg = {}
 					bg.type = ext
 					bg.url = themeDir .. fs.basename(f)
@@ -59,44 +66,58 @@
 		end
 		return backgroundTable,backgroundCount
 	end
+	local function selectBackground(themeDir)
+		local bgUrl 			= media .. "/img/bg1.jpg"
+		local backgroundType 	= "Image"
+		local mimeType 			= ""
 
-	local boardinfo			= util.ubus("system", "board")
-	local themeDir			= media .. "/background/"
-	local bgUrl 			= media .. "/img/bg1.jpg"
-	local useBing			= fs.access('/etc/config/argon') and uci:get_first('argon', 'global', 'bing_background') or "0"
-	local backgroundTable, backgroundCount 		= fetchMedia("/www" .. themeDir .. "*",themeDir)
-	local backgroundType 	= "Image"
-
-	function getBing()
-		local bing = sys.exec("/usr/libexec/argon/bing_wallpaper")
-		if (bing and bing ~= '') then
-			bgUrl 	= bing
+		if fs.access("/etc/config/argon") then
+			if uci:get_first('argon', 'global', 'bing_background') == "1" then
+				local bing = sys.exec("/usr/libexec/argon/bing_wallpaper")
+				if (bing and bing ~= '') then
+					return bing, "Image", ""
+				end
+			end
 		end
-	end
 
-	if ( useBing == "0" ) then
+		local backgroundTable, backgroundCount 		= fetchMedia("/www" .. themeDir .. "*",themeDir)
 		if ( backgroundCount > 0 ) then
 			local currentBg = backgroundTable[math.random(1,backgroundCount)]
 			bgUrl 			= currentBg.url
-			if (currentBg.type == "mp4" ) then
+			if (string.match(videoTypes, " "..currentBg.type.." ") ~= nil) then
 				backgroundType 	= "Video"
+				mimeType 		= "video/" .. currentBg.type
 			end
 		end
-	else
-		pcall(getBing)
+
+		return bgUrl,backgroundType,mimeType
 	end
+
+	local boardinfo			= util.ubus("system", "board")
+	local themeDir			= media .. "/background/"
+	local bgUrl,backgroundType,mimeType = selectBackground(themeDir)
 %>
 <!-- Login Page Start -->
 <div class="login-page">
-	
 	<% if ( backgroundType == "Video" ) then %>
 	<!-- Video Player Start -->
-	<div class="video ar-flex ar-justify-content-center ar-align-items-center">
+	<div class="video">
 		<video autoplay loop muted id="video">
-			<source src="<%=bgUrl%>" type="video/mp4">
+			<source src="<%=bgUrl%>" type="<%=mimeType%>">
 		</video>
 	</div>
 	<div class="volume-control mute"></div>
+	<script>
+		$(".volume-control").click(function(){
+			if($(this).hasClass("mute")){
+				$(this).removeClass("mute")
+				$("#video").prop('muted', false);
+			}else{
+				$(this).addClass("mute")
+				$("#video").prop('muted', true);
+			}
+		})
+	</script>
 	<!-- Video Player End -->
 	<% else %>
 	<!-- Image Background Start -->
@@ -106,8 +127,12 @@
 	<!-- Login Container Start -->
 	<div class="login-container">
 		<div class="login-form">
-			<a class="brand" href="/"><img src="<%=media%>/img/argon.svg" class="icon"><span
-					class="brand-text"><%=striptags( (boardinfo.hostname or "?") .. ( (node and node.title) and ' - ' .. translate(node.title) or '')) %></span></a>
+			<!-- Logo Start -->
+			<a class="brand" href="/"><img src="<%=media%>/img/argon.svg" class="icon">
+			<span class="brand-text"><%=striptags( (boardinfo.hostname or "?") .. ( (node and node.title) and ' - ' .. translate(node.title) or '')) %></span>
+			</a>
+			<!-- Logo End -->
+			<!-- Login Form Start -->
 			<form class="form-login" method="post" action="<%=pcdata(luci.http.getenv("REQUEST_URI"))%>">
 
 				<%- if fuser then %>
@@ -128,7 +153,7 @@
 					<input type="submit" value="<%:Login%>" class="cbi-button cbi-button-apply" />
 				</div>
 			</form>
-
+			<!-- Login Form End -->
 			<script type="text/javascript">//<![CDATA[
 				var input = document.getElementsByName('luci_password')[0];
 				if (input)


### PR DESCRIPTION
1.合并master，登录页面支持webp格式图片
2.合并master，添加/修复 https://github.com/jerrykuku/luci-theme-argon/issues/333 https://github.com/jerrykuku/luci-theme-argon/issues/343 https://github.com/jerrykuku/luci-theme-argon/issues/383 视频静音功能的逻辑
3.修复 https://github.com/jerrykuku/luci-theme-argon/issues/256 https://github.com/jerrykuku/luci-theme-argon/issues/355 某些文本输入框过小(常见于移动端)
4.修复 https://github.com/jerrykuku/luci-theme-argon/issues/334 访问 **_状态>概览(首页)_** 的 **_DHCPv6分配_** 中的某些主机名无法居中显示