### PR TITLE
fix: 修复URL子路径匹配bug

### DIFF
--- a/htdocs/luci-static/argon/js/script.js
+++ b/htdocs/luci-static/argon/js/script.js
@@ -68,6 +68,7 @@
      */
     function getCurrentNodeByUrl() {
         var ret = false;
+        const urlReg = new RegExp(nodeUrl + "$")
         if (!$('body').hasClass('logged-in')) {
             luciLocation = ["Main", "Login"];
             return true;
@@ -81,7 +82,7 @@
                 var that = $(this);
                 var href = that.attr("href");
 
-                if (href.indexOf(nodeUrl) != -1) {
+                if (urlReg.test(href)) {
                     ulNode.click();
                     ulNode.next(".slide-menu").stop(true, true);
                     lastNode = that.parent();


### PR DESCRIPTION
- 未修复前，打开passwall插件，导致passwall、passwall2插件处于同时选中状态，并且菜单栏无法自动展开。类似的插件还有luci-app-ddns、luci-app-ddnsto。
> indexof方法是查找的子串匹配，导致service/passwall、service/passwall2同时选中状态。修改使用正则替换，保证是以完整的子串结尾匹配才选中。

https://github.com/gngpp/luci-theme-design/blob/47ed33e76474e9f2b61a47bd9cac00f7fa1303f8/dev/script.js#L60

![image](https://user-images.githubusercontent.com/51810656/229782479-75bf4f58-0733-4b9b-aaca-04c943f8767c.png)
