### PR TITLE
18.06 优化&修补 添加Actions自动编译主题ipk

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -1,0 +1,132 @@
+#
+# Copyright (c) 2022-2023 SMALLPROGRAM <https://github.com/smallprogram>
+# Description: Auto compile
+#
+name: "Auto compile with openwrt sdk (18.06)"
+on:
+  repository_dispatch:
+  workflow_dispatch:
+    inputs:
+      ssh:
+        description: 'SSH connection to Actions'
+        required: false
+        default: 'false'
+  push:
+    branches:
+      - '18.06'
+    paths:
+      - 'luci-theme-argon/Makefile'
+env:
+  TZ: Asia/Shanghai
+
+
+jobs:
+  job_check:
+    if: github.repository == 'jerrykuku/luci-theme-argon'
+    name: Check Version
+    runs-on: ubuntu-latest
+    outputs:
+      argon_version: ${{ steps.check_version.outputs.latest_version }}
+      has_update: ${{ steps.check_version.outputs.has_update }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+          ref: '18.06'
+
+      - name: Check version
+        id: check_version
+        env:
+          url_release: https://api.github.com/repos/jerrykuku/luci-theme-argon/releases/latest
+        run: |
+          latest_version=$(awk -F ':=' '/PKG_VERSION|PKG_RELEASE/ {print $2}' Makefile | sed ':a;N;s/\n$//;s/\n/-/;ba')
+          latest_release=$(wget -qO- -t1 -T2 ${{env.url_release}} | awk -F '"' '/tag_name/{print $4}')
+          has_update=$([ "${latest_version}" != "${latest_release}" ] && echo true || echo false)
+          echo "latest_version=${latest_version}" >> $GITHUB_OUTPUT
+          echo "has_update=${has_update}" >> $GITHUB_OUTPUT
+          echo "latest_version: ${latest_version}"
+          echo "latest_release: ${latest_release}"
+          echo "has_update: ${has_update}"
+
+      - name: Generate new tag & release
+        if: steps.check_version.outputs.has_update == 'true'
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{steps.check_version.outputs.latest_version}}
+
+
+  job_build_argon:
+    name: Build Argon
+    needs: job_check
+    if: needs.job_check.outputs.has_update == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install packages
+        run: |
+          echo "Install packages"
+          sudo -E apt-get -qq update
+          sudo -E apt-get -qq install build-essential clang flex bison g++ gawk gcc-multilib g++-multilib gettext git libncurses5-dev libssl-dev python3-distutils rsync unzip zlib1g-dev file wget
+          sudo -E apt-get -qq autoremove --purge
+          sudo -E apt-get -qq clean
+
+      - name: Cache openwrt SDK
+        id: cache-sdk
+        uses: actions/cache@v3
+        with:
+          path: sdk
+          key: openwrt-sdk-18.06-x86_64
+
+      - name: Initialization environment
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        env:
+          url_sdk: https://archive.openwrt.org/releases/18.06.9/targets/x86/64/openwrt-sdk-18.06.9-x86-64_gcc-7.3.0_musl.Linux-x86_64.tar.xz
+        run: |
+          wget ${{ env.url_sdk }}
+          file_name=$(echo ${{env.url_sdk}} | awk -F/ '{print $NF}')
+          mkdir sdk && tar -xJf $file_name -C ./sdk --strip-components=1
+          cd sdk
+          echo "src-git base https://github.com/openwrt/openwrt.git;openwrt-18.06" > feeds.conf
+          echo "src-git-full packages https://github.com/openwrt/packages.git;openwrt-18.06" >> feeds.conf
+          echo "src-git-full luci https://git.openwrt.org/project/luci.git;openwrt-18.06" >> feeds.conf
+          echo "src-git-full routing https://git.openwrt.org/feed/routing.git;openwrt-18.06"  >> feeds.conf
+          git clone -b 18.06 https://github.com/jerrykuku/luci-theme-argon.git package/downloads/luci-theme-argon
+          ./scripts/feeds update -a
+          echo "CONFIG_PACKAGE_luci-theme-argon=m" > .config
+          ./scripts/feeds install -d n luci-theme-argon
+          make download -j8
+
+      - name: Configure Argon
+        run: |
+          cd sdk
+          ./scripts/feeds install luci-theme-argon
+          echo "CONFIG_ALL_NONSHARED=n" > .config
+          echo "CONFIG_ALL_KMODS=n" >> .config
+          echo "CONFIG_ALL=n" >> .config
+          echo "CONFIG_AUTOREMOVE=n" >> .config
+          echo "CONFIG_LUCI_LANG_zh_Hans=y" >> .config
+          echo "CONFIG_PACKAGE_luci-theme-argon=m" >> .config
+          make defconfig
+
+      - name: Compile Argon
+        id: compile
+        run: |
+          cd sdk
+          echo "make package/luci-theme-argon/{clean,compile} -j$(nproc)"
+          make package/luci-theme-argon/{clean,compile} -j$(nproc)
+          mv bin/packages/x86_64/base/ ../
+          rm .config .config.old
+          cd ..
+          echo "status=success" >> $GITHUB_OUTPUT
+          echo "FIRMWARE=$PWD" >> $GITHUB_ENV
+
+      - name: Upload Argon ipks to release
+        uses: softprops/action-gh-release@v1
+        if: steps.compile.outputs.status == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{needs.job_check.outputs.argon_version}}
+          files: ${{ env.FIRMWARE }}/base/luci-theme*.ipk

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -3014,10 +3014,6 @@ input[name="nslookup"] {
   header > .fill > .container > .brand {
     display: inline-block;
   }
-  .cbi-value-title {
-    width: 9rem;
-    padding-right: 1rem;
-  }
   .node-network-diagnostics > .main .cbi-map fieldset > div * {
     width: 100% !important;
   }

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2706,7 +2706,7 @@ td > .ifacebadge,
   min-width: 7rem;
 }
 .cbi-section-create > .cbi-button-add {
-  margin: 0.5rem 0.5rem 0.5rem 0;
+  margin: 0.75rem 0.75rem 0.75rem 0.25rem;
 }
 .cbi-section-remove {
   padding: 0.5rem;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1216,7 +1216,7 @@ ul li .cbi-input-checkbox {
 }
 .cbi-section-create {
   margin: 0;
-  padding-left: 1rem;
+  padding-left: 0.5rem;
   align-items: center;
 }
 .cbi-section-create > * {
@@ -2705,7 +2705,7 @@ td > .ifacebadge,
   min-width: 7rem;
 }
 .cbi-section-create > .cbi-button-add {
-  margin: 0.5rem 0.5rem 0.5rem 0.5rem;
+  margin: 0.5rem 0.5rem 0.5rem 0;
 }
 .cbi-section-remove {
   padding: 0.5rem;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2438,7 +2438,7 @@ select[multiple="multiple"] {
   overflow-y: visible;
 }
 .cbi-section-node .cbi-value {
-  padding: 0.3rem 1rem 0.3rem 1rem;
+  padding: 0.5rem 1rem 0.5rem 1rem !important;
 }
 .cbi-tabcontainer > .cbi-value:nth-of-type(2n) {
   background-color: #f9f9f9;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2804,6 +2804,10 @@ input[name="nslookup"] {
   border-right: 0 !important;
   background-color: #5e72e4 !important;
   background-color: var(--primary) !important;
+  height: 100% !important;
+  background-image: url(../img/trafficbar.png);
+  background-position: left top;
+  animation: sparkle 1500ms linear infinite;
 }
 .node-system-leds .cbi-section em {
   display: block;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -889,7 +889,7 @@ footer a {
   box-shadow: 0 0px 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2);
 }
 .cbi-button:active {
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.19), 0 5px 5px rgba(0, 0, 0, 0.23);
 }
 .cbi-button:disabled {
   cursor: not-allowed;
@@ -1481,7 +1481,7 @@ td > table > tbody > tr > td,
   box-shadow: 0 0px 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2);
 }
 ::file-selector-button:active {
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.19), 0 5px 5px rgba(0, 0, 0, 0.23);
 }
 /* table */
 .cbi-section-table .cbi-section-table-titles .cbi-section-table-cell {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2480,7 +2480,6 @@ form > .cbi-map > .cbi-section > .cbi-section-node > .cbi-value > .cbi-value-fie
   padding: 0.7rem;
   padding-left: 0;
   width: 23rem;
-  float: left;
   text-align: right;
   display: table-cell;
 }

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1370,6 +1370,7 @@ input[name="nslookup"] {
   height: 1.6rem !important;
   line-height: 1.6rem;
   border-radius: 0.25rem;
+  overflow: hidden;
 }
 #swaptotal > div > div,
 #swapfree > div > div,

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1083,12 +1083,13 @@ input[type="checkbox"] {
   appearance: none !important;
   -webkit-appearance: none !important;
   border: 1px solid #dee2e6;
-  width: 16px !important;
-  height: 16px !important;
+  width: 17px !important;
+  height: 17px !important;
   padding: 0;
   cursor: pointer;
   transition: all 0.2s;
-  margin: 0.9rem 0.25rem 0 0.25rem;
+  margin: 0.5rem 0.25rem 0.7rem 0.25rem;
+  vertical-align: middle;
 }
 input[type="checkbox"]:checked {
   border: 1px solid #5e72e4;
@@ -1101,14 +1102,15 @@ input[type="checkbox"]:checked {
   background-position: center;
 }
 ul li .cbi-input-checkbox {
-  margin: 0.5rem 0.25rem !important;
+  margin: 0.5rem 0.25rem 0.7rem 0.25rem !important;
+  vertical-align: middle !important;
 }
 .cbi-input-radio {
   appearance: none !important;
   -webkit-appearance: none !important;
   border: 1px solid #dee2e6;
-  width: 16px !important;
-  height: 16px !important;
+  width: 17px !important;
+  height: 17px !important;
   padding: 0;
   border-radius: 50%;
   cursor: pointer;
@@ -2667,16 +2669,20 @@ td > .ifacebadge,
   min-width: 10rem;
   margin-top: 0.3rem;
 }
-.cbi-value-field .cbi-input-checkbox,
-.cbi-value-field .cbi-input-radio {
-  margin: 0.9rem 0.25rem 0 0.25rem;
+.cbi-value-field .cbi-input-checkbox {
+  margin: 0.5rem 0.25rem 0.7rem 0.25rem;
+  vertical-align: middle;
   height: 1rem;
   line-height: 1.6;
 }
 .cbi-input-checkbox {
-  margin: 0.9rem 0.25rem 0 0.25rem;
+  margin: 0.5rem 0.25rem 0.7rem 0.25rem;
+  vertical-align: middle;
 }
 .cbi-value-field .cbi-input-radio {
+  margin: 0rem 0.25rem;
+}
+.cbi-input-radio {
   margin: 0rem 0.25rem;
 }
 .cbi-value-field > input + .cbi-value-description {
@@ -3118,12 +3124,6 @@ input[name="nslookup"] {
     display: inline-block;
     width: 100%;
     position: relative;
-  }
-  .cbi-value-field .cbi-input-checkbox,
-  .cbi-value-field .cbi-input-radio {
-    margin: 0rem 0.25rem 0 0.25rem;
-    height: 1rem;
-    line-height: 1.6;
   }
   .cbi-page-actions > div > input {
     display: none;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1109,8 +1109,8 @@ ul li .cbi-input-checkbox {
   appearance: none !important;
   -webkit-appearance: none !important;
   border: 1px solid #dee2e6;
-  width: 17px !important;
-  height: 17px !important;
+  width: 16px !important;
+  height: 16px !important;
   padding: 0;
   border-radius: 50%;
   cursor: pointer;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2174,7 +2174,7 @@ td > table > tbody > tr > td {
 }
 .cbi-tabmenu {
   color: white;
-  padding: 0.5rem 1rem 0 1rem;
+  padding: 0.5rem 0.5rem 0 0.5rem;
   white-space: nowrap;
   overflow-x: auto;
   border-bottom: 1px solid #ddd !important;

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -209,6 +209,7 @@ table>thead>tr>td {
 
 .node-system-packages>.main .cbi-section-node:first-child .cbi-value-last div[style="margin:3px 0; width:300px; height:10px; border:1px solid #000000; background-color:#80C080"] div {
   background-color: #32325d !important;
+  background-color: var(--dark-primary) !important;
 }
 
 table>tbody>tr>th,

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1327,8 +1327,8 @@ ul li .cbi-input-checkbox {
     -webkit-appearance: none !important;
     border: 1px solid #dee2e6;
 
-    width: 17px !important;
-    height: 17px !important;
+    width: 16px !important;
+    height: 16px !important;
     padding: 0;
     border-radius: 50%;
     cursor: pointer;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1060,7 +1060,7 @@ footer {
 }
 
 .cbi-button:active {
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.19), 0 5px 5px rgba(0, 0, 0, 0.23);
 }
 
 .cbi-button:disabled {
@@ -1768,7 +1768,7 @@ td>table>tbody>tr>td,
     box-shadow: 0 0px 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2);
 }
 ::file-selector-button:active {
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.19), 0 5px 5px rgba(0, 0, 0, 0.23);
 }
 
 /* table */

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2640,7 +2640,7 @@ td>table>tbody>tr>td {
 
 .cbi-tabmenu {
     color: white;
-    padding: 0.5rem 1rem 0 1rem;
+    padding: 0.5rem 0.5rem 0 0.5rem;
     white-space: nowrap;
     overflow-x: auto;
     border-bottom: 1px solid #ddd !important;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1296,13 +1296,14 @@ input[type="checkbox"] {
     -webkit-appearance: none !important;
     border: 1px solid #dee2e6;
 
-    width: 16px !important;
-    height: 16px !important;
+    width: 17px !important;
+    height: 17px !important;
     padding: 0;
     cursor: pointer;
     transition: all 0.2s;
 
-    margin: 0.9rem 0.25rem 0 0.25rem;
+    margin: 0.5rem 0.25rem 0.7rem 0.25rem;
+    vertical-align: middle;
 }
 
 input[type="checkbox"]:checked {
@@ -1317,7 +1318,8 @@ input[type="checkbox"]:checked {
 }
 
 ul li .cbi-input-checkbox {
-    margin: 0.5rem 0.25rem !important;
+    margin: 0.5rem 0.25rem 0.7rem 0.25rem !important;
+    vertical-align: middle !important;
 }
 
 .cbi-input-radio {
@@ -1325,8 +1327,8 @@ ul li .cbi-input-checkbox {
     -webkit-appearance: none !important;
     border: 1px solid #dee2e6;
 
-    width: 16px !important;
-    height: 16px !important;
+    width: 17px !important;
+    height: 17px !important;
     padding: 0;
     border-radius: 50%;
     cursor: pointer;
@@ -3262,21 +3264,25 @@ td>.ifacebadge,
     margin-top: 0.3rem;
 }
 
-.cbi-value-field .cbi-input-checkbox,
-.cbi-value-field .cbi-input-radio {
-    margin: 0.9rem 0.25rem 0 0.25rem;
+.cbi-value-field .cbi-input-checkbox {
+    margin: 0.5rem 0.25rem 0.7rem 0.25rem;
+    vertical-align: middle;
     height: 1rem;
     line-height: 1.6;
 }
 
 .cbi-input-checkbox {
-    margin: 0.9rem 0.25rem 0 0.25rem;
+    margin: 0.5rem 0.25rem 0.7rem 0.25rem;
+    vertical-align: middle;
 }
 
 .cbi-value-field .cbi-input-radio {
     margin: 0rem 0.25rem;
 }
 
+.cbi-input-radio {
+    margin: 0rem 0.25rem;
+}
 
 .cbi-value-field>input+.cbi-value-description {
     padding: 0;
@@ -3883,13 +3889,6 @@ input[name="nslookup"] {
         display: inline-block;
         width: 100%;
         position: relative;
-    }
-
-    .cbi-value-field .cbi-input-checkbox,
-    .cbi-value-field .cbi-input-radio {
-        margin: 0rem 0.25rem 0 0.25rem;
-        height: 1rem;
-        line-height: 1.6;
     }
 
     .cbi-page-actions>div>input {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1636,6 +1636,7 @@ input[name="nslookup"] {
     height: 1.6rem !important;
     line-height: 1.6rem;
     border-radius: .25rem;
+    overflow: hidden;
 }
 
 #swaptotal>div>div,

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1452,7 +1452,7 @@ ul li .cbi-input-checkbox {
 
 .cbi-section-create {
     margin: 0;
-    padding-left: 1rem;
+    padding-left: 0.5rem;
     align-items: center;
 
 }
@@ -3310,7 +3310,7 @@ td>.ifacebadge,
 }
 
 .cbi-section-create>.cbi-button-add {
-    margin: 0.5rem 0.5rem 0.5rem 0.5rem;
+    margin: 0.5rem 0.5rem 0.5rem 0;
 }
 
 .cbi-section-remove {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2965,7 +2965,7 @@ select[multiple="multiple"] {
 
 
 .cbi-section-node .cbi-value {
-    padding: 0.3rem 1rem 0.3rem 1rem;
+    padding: 0.5rem 1rem 0.5rem 1rem !important;
 }
 
 

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3442,6 +3442,10 @@ input[name="nslookup"] {
             border-right: 0 !important;
             background-color: #5e72e4 !important;
             background-color: var(--primary) !important;
+            height: 100% !important;
+            background-image: url(../img/trafficbar.png);
+            background-position: left top;
+            animation: sparkle 1500ms linear infinite;
         }
     }
 

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3311,7 +3311,7 @@ td>.ifacebadge,
 }
 
 .cbi-section-create>.cbi-button-add {
-    margin: 0.5rem 0.5rem 0.5rem 0;
+    margin: 0.75rem 0.75rem 0.75rem 0.25rem;
 }
 
 .cbi-section-remove {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3017,7 +3017,6 @@ form>.cbi-map>.cbi-section>.cbi-section-node>.cbi-value>.cbi-value-field font {
     padding: .7rem;
     padding-left: 0;
     width: 23rem;
-    float: left;
     text-align: right;
     display: table-cell;
 }

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3730,15 +3730,8 @@ input[name="nslookup"] {
         font-size: 1.7rem;
     }
 
-
-
     header>.fill>.container>.brand {
         display: inline-block;
-    }
-
-    .cbi-value-title {
-        width: 9rem;
-        padding-right: 1rem;
     }
 
     .node-network-diagnostics>.main .cbi-map fieldset>div * {

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -272,6 +272,7 @@ table>thead>tr>td {
 
         div {
             background-color: #32325d !important;
+            background-color: var(--dark-primary) !important;
         }
     }
 


### PR DESCRIPTION
- 减少按钮按下的阴影扩散效果,这将改进在移动端上的显示效果 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/4d56662712d8be07632205ef3888ca53f9e8e09c
- 为 _软件包[Software]_ 中 _空闲空间[Free space]_ 的占用指示条 增加气泡动画,并支持跟随自定义主题颜色 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/86b27d166d6ff3ad873cb224b588457c065cd189
- 优化列表布局 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/169b2b2db6b4f118e89509c72dce124ac1898fa8
- 使列表中的标题与选框/输入框对齐 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/2934fb9ef75ba7999db25f86ca313c3c15eda3eb
- 重新对齐复选框;稍稍增大复选框1px https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/e4a83fecc254f1a87c71591b6e85719fa716632e https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/4c87de8975774646cc20a857c005e53960c9a1ca
- 优化 在浏览器窗口较小时/缩小浏览器窗口时/在移动端页面时 列表内标题换行显示的最小宽度 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/57eec643f612bbb4c9f2682bcfa4b914f07aa9c9
- 优化 _添加[Add]_ 按钮的位置 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/d20c82abf051f12c1b5e5c43c8ae98fc9710bebe https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/9cb71a6df905c80dd2ea17fc220ca3d0b35cdaa1
- 优化 _子选项卡[Sub-tabs]_ 的位置
- 优化 _概况[overview]_ 中的 占用指示条,避免内部颜色溢出边框四角 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/4494a237bd1c4ac92c1ea8b68275eee087dbe3fa
---
- 18.06 支持 手动触发自动编译,并创建和上传到发行版 https://github.com/jerrykuku/luci-theme-argon/pull/402/commits/fe497723f51c9df5f8d1b86ced0e56e8fcf1e533