### PR TITLE
18.06: Update to v1.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
 LUCI_DEPENDS:=+curl +jsonfilter
-PKG_VERSION:=1.8.0
-PKG_RELEASE:=20230521
+PKG_VERSION:=1.8.1
+PKG_RELEASE:=20230527
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -155,6 +155,23 @@ body {
   color: #ffffff;
   color: var(--white);
 }
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar,
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: #9e9e9e;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #757575;
+}
+::-webkit-scrollbar-thumb:active {
+  background: #424242;
+}
 a:link,
 a:visited,
 a:active {
@@ -568,8 +585,7 @@ footer a {
   background-color: var(--menubar-scrollbar-thumb);
 }
 .main .main-left::-webkit-scrollbar-track {
-  background-color: #fff;
-  background-color: var(--menubar-background);
+  background-color: transparent;
 }
 .main .main-left .sidenav-header {
   padding: 1.5rem;
@@ -2154,15 +2170,23 @@ td > table > tbody > tr > td {
   white-space: nowrap;
   overflow-x: auto;
 }
-.tabs::-webkit-scrollbar {
+.tabs::-webkit-scrollbar,
+.cbi-section::-webkit-scrollbar,
+.cbi-section > *::-webkit-scrollbar {
   width: 1px;
   height: 5px;
 }
 .tabs::-webkit-scrollbar-thumb {
-  background-color: #f6f9fc;
+  background-color: #9e9e9e;
+}
+.tabs::-webkit-scrollbar-thumb:hover {
+  background: #757575;
+}
+.tabs::-webkit-scrollbar-thumb:active {
+  background: #424242;
 }
 .tabs::-webkit-scrollbar-track {
-  background-color: #fff;
+  background-color: transparent;
 }
 .tabs li[class~="active"],
 .tabs li:hover {
@@ -2207,10 +2231,16 @@ td > table > tbody > tr > td {
   height: 5px;
 }
 .cbi-tabmenu::-webkit-scrollbar-thumb {
-  background-color: #f6f9fc;
+  background-color: #9e9e9e;
+}
+.cbi-tabmenu::-webkit-scrollbar-thumb:hover {
+  background: #757575;
+}
+.cbi-tabmenu::-webkit-scrollbar-thumb:active {
+  background: #424242;
 }
 .cbi-tabmenu::-webkit-scrollbar-track {
-  background-color: #fff;
+  background-color: transparent;
 }
 .cbi-tabmenu li {
   background: #dce3e9;
@@ -2527,23 +2557,6 @@ form > .cbi-map > .cbi-section > .cbi-section-node > .cbi-value > .cbi-value-fie
 }
 .cbi-section-table .cbi-section-table-titles .cbi-section-table-cell {
   width: auto !important;
-}
-::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-::-webkit-scrollbar,
-::-webkit-scrollbar-corner {
-  background: transparent;
-}
-::-webkit-scrollbar-thumb {
-  background: #9e9e9e;
-}
-::-webkit-scrollbar-thumb:hover {
-  background: #757575;
-}
-::-webkit-scrollbar-thumb:active {
-  background: #424242;
 }
 /* desc */
 .cbi-section-descr {
@@ -3138,10 +3151,9 @@ input[name="nslookup"] {
   .cbi-page-actions > div > input {
     display: none;
   }
-  .tabs::-webkit-scrollbar,
-  .cbi-tabmenu::-webkit-scrollbar {
-    width: 0px;
-    height: 0px;
+  ::-webkit-scrollbar {
+    width: 0px !important;
+    height: 0px  !important;
   }
   .tabs > li > a {
     font-size: 0.9rem;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -178,7 +178,7 @@ a:active {
   color: var(--primary);
   text-decoration: none;
 }
-a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a) {
+a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a, .cbi-button) {
   color: -webkit-link;
   cursor: pointer;
   color: var(--primary);

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2170,7 +2170,7 @@ td > table > tbody > tr > td {
   border-bottom: 0.18751rem solid var(--primary);
   color: #5e72e4;
   color: var(--primary);
-  background-color: #dce1fe;
+  background-color: var(--light-subtabs-background);
   margin-bottom: 0;
   border-radius: 0;
 }
@@ -2231,7 +2231,7 @@ td > table > tbody > tr > td {
   border-bottom: 0.18751rem solid var(--primary);
   color: #5e72e4;
   color: var(--primary);
-  background-color: #dce1fe;
+  background-color: var(--light-subtabs-background);
   margin-bottom: 0;
 }
 .cbi-tabmenu li:hover a {
@@ -2241,7 +2241,7 @@ td > table > tbody > tr > td {
   border-bottom: 0.18751rem solid #5e72e4;
   border-bottom: 0.18751rem solid var(--primary);
   color: var(--primary);
-  background-color: #dce1fe;
+  background-color: var(--light-subtabs-background);
   margin-bottom: 0;
 }
 .cbi-tabmenu li[class~="cbi-tab"] a {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2101,6 +2101,8 @@ fieldset.cbi-section p {
   letter-spacing: 0.1rem;
   color: #32325d;
   font-weight: 600;
+  position: sticky;
+  left: 0;
 }
 table {
   border-spacing: 0;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -575,6 +575,7 @@ footer a {
   position: fixed;
   z-index: 100;
   transition: width 0.2s ease-in-out;
+  overflow-y: overlay;
 }
 .main .main-left::-webkit-scrollbar {
   width: 5px;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2059,7 +2059,7 @@ h3 {
   letter-spacing: 0.1rem;
   padding: 1rem 1.5rem;
   border-radius: 0.375rem;
-  background: #fff;
+  background: var(--lighter);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.03);
 }
 fieldset {
@@ -2866,7 +2866,6 @@ input[name="nslookup"] {
   text-align: center;
 }
 .cbi-section h4 {
-  padding: 0.75rem 1.5rem;
   font-size: 0.7rem;
   font-weight: 600;
   color: #525f7f;
@@ -2939,7 +2938,7 @@ input[name="nslookup"] {
 .node-nas-usb_printer em {
   display: block;
 }
-/* PassWall */
+/* luci-app-passwall */
 #cbi-passwall #add_link_div,
 #cbi-passwall #set_node_div {
   background: #fffffff0;
@@ -2952,6 +2951,28 @@ input[name="nslookup"] {
 }
 #cbi-passwall .cbi-section-table tbody ._now_use {
   background: #5e72e473 !important;
+}
+/* luci-app-commands */
+.commandbox h3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.commandbox code {
+  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+div.commandbox {
+  height: 16em;
+}
+/* luci-app-ssr-plus */
+#cbi-shadowsocksr .cbi-map-descr h3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 @media screen and (max-width: 1600px) {
   .main .main-left {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -226,7 +226,8 @@ li {
 }
 .login-page .video video {
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
 }
 .login-page .volume-control {
   position: fixed;
@@ -3054,10 +3055,6 @@ input[name="nslookup"] {
   .pull-right {
     float: right;
     margin-top: 0rem !important;
-  }
-  .login-page .video video {
-    width: auto !important;
-    height: 100% !important;
   }
   .login-page .login-container {
     margin-left: 0rem !important;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -317,7 +317,7 @@ li {
   text-decoration: none;
 }
 .login-page .login-container .login-form .form-login {
-  width: 100%;
+  width: 420px;
   padding: 20px 50px;
   box-sizing: border-box;
 }
@@ -3044,6 +3044,15 @@ input[name="nslookup"] {
   }
   #diag-rc-output > pre {
     font-size: 1rem;
+  }
+}
+@media screen and (max-width: 500px) {
+  .login-page .login-container {
+    margin-left: 0rem !important;
+    width: 500px;
+  }
+  .login-page .login-container .login-form {
+    max-width: 500px;
   }
 }
 @media screen and (max-width: 480px) {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -964,9 +964,6 @@ form.inline + form.inline,
   border-color: #5e72e4 !important;
   border-color: var(--primary) !important;
 }
-.cbi-button-add {
-  margin-left: 1.5rem;
-}
 .node-services-vssr .ssr-button {
   margin-left: 0.3rem;
 }

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -47,7 +47,7 @@
   --warning: #fb6340;
   --footer-color: #aaa;
   --menubar-background: #fff;
-  --menubar-scrollbar-thumb: #f6f9fc;
+  --menubar-scrollbar-thumb: #eee;
   --menubar-text-color: #4c4c4c;
   --blue: #5e72e4;
   --indigo: #5603ad;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2243,7 +2243,7 @@ td > table > tbody > tr > td {
   background-color: transparent;
 }
 .cbi-tabmenu li {
-  background: #dce3e9;
+  background: #e3e3e3;
   display: inline-block;
   font-size: 0.875rem;
   border-top-left-radius: 0.25rem;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2173,7 +2173,7 @@ td > table > tbody > tr > td {
 .tabs::-webkit-scrollbar,
 .cbi-section::-webkit-scrollbar,
 .cbi-section > *::-webkit-scrollbar {
-  width: 1px;
+  width: 5px;
   height: 5px;
 }
 .tabs::-webkit-scrollbar-thumb {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2528,6 +2528,23 @@ form > .cbi-map > .cbi-section > .cbi-section-node > .cbi-value > .cbi-value-fie
 .cbi-section-table .cbi-section-table-titles .cbi-section-table-cell {
   width: auto !important;
 }
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar,
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: #9e9e9e;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #757575;
+}
+::-webkit-scrollbar-thumb:active {
+  background: #424242;
+}
 /* desc */
 .cbi-section-descr {
   padding: 1rem 1.5rem;
@@ -2983,25 +3000,6 @@ input[name="nslookup"] {
   }
   .main > .main-left > .nav > .slide > .slide-menu > li > a {
     font-size: 0.7rem;
-  }
-}
-@media screen and (min-width: 600px) {
-  ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-  }
-  ::-webkit-scrollbar,
-  ::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-  ::-webkit-scrollbar-thumb {
-    background: #9e9e9e;
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    background: #757575;
-  }
-  ::-webkit-scrollbar-thumb:active {
-    background: #424242;
   }
 }
 @media screen and (max-width: 992px) {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -283,6 +283,7 @@ li {
   max-width: 420px;
   background-color: #fff;
   background-color: var(--white);
+  overflow:hidden;
 }
 .login-page .login-container .login-form .brand {
   display: flex;
@@ -308,7 +309,7 @@ li {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
 .login-page .login-container .login-form .brand:hover {
@@ -3061,9 +3062,6 @@ input[name="nslookup"] {
   .login-page .login-container {
     margin-left: 0rem !important;
     width: 100%;
-  }
-  .login-page .login-container .login-form {
-    max-width: 480px;
   }
   .login-page .login-container .login-form .form-login .input-group::before {
     color: #525461;

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -701,7 +701,7 @@ fieldset[id^="cbi-apply-"] {
 
 /* luci-app-openclash */
 #cbi-openclash #eye-icon,
-#cbi-openclash img[title="Ë¢ÐÂ"] {
+#cbi-openclash img[title="åˆ·æ–°"] {
   filter: invert(100%);
 }
 #cbi-openclash #cbi-openclash-config fieldset[control-id="ControlID-46"],

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -533,7 +533,7 @@ td.cbi-value-field var,
 
 .node-services-vssr .block {
   background-color: #1e1e1e !important;
-  box-shadow: 0 0 .5rem 0 rgba(0,0,0,0.35);
+  box-shadow: 0 0 .5rem 0 rgba(0,0,0,0.35) !important;
 }
 
 .node-services-vssr .block h4 {
@@ -542,8 +542,8 @@ td.cbi-value-field var,
 
 .node-services-vssr .status-bar {
   color: #ccc;
-  box-shadow: 0 0 .5rem 0 rgba(0,0,0,0.35);
-  background-color: #1e1e1e;
+  background: #333333f0;
+  box-shadow: #00000094 10px 10px 30px 5px;
 }
 
 .node-services-vssr .cbi-section-table-row {
@@ -675,7 +675,7 @@ fieldset[id^="cbi-apply-"] {
   color: #ccc !important;
 }
 
-/* PassWall */
+/* luci-app-passwall */
 #cbi-passwall #add_link_div,
 #cbi-passwall #set_node_div {
   background: #333333f0 !important;
@@ -683,6 +683,44 @@ fieldset[id^="cbi-apply-"] {
 }
 #cbi-passwall #add_link_div #nodes_link {
   background: #3c3c3c  !important;
+}
+
+/* luci-app-bypass */
+#cbi-bypass .status-bar {
+  color: #ccc;
+  background: #333333f0;
+  box-shadow: #00000094 10px 10px 30px 5px;
+}
+
+/* luci-app-clash */
+#cbi-clash .cbi-section .pure-u-1-4 .pure-g,
+#cbi-clash .cbi-section .siz .pure-g {
+  background-color: #1e1e1e !important;
+  box-shadow: 0 0 .5rem 0 rgba(0,0,0,0.35) !important;
+}
+
+/* luci-app-openclash */
+#cbi-openclash #eye-icon,
+#cbi-openclash img[title="Ë¢ÐÂ"] {
+  filter: invert(100%);
+}
+#cbi-openclash #cbi-openclash-config fieldset[control-id="ControlID-46"],
+#cbi-openclash .CodeMirror-merge-copybuttons-right,
+.CodeMirror-scroll {
+  background-color: #333333 !important;
+}
+#cbi-openclash .cbi-section .cbi-tabmenu li {
+  border-right: 1px solid #3c3c3c !important;
+}
+#cbi-openclash .CodeMirror-merge {
+  border: 1px solid transparent !important;
+}
+#cbi-openclash-config-clog .cbi-section {
+  border: 1px solid #3c3c3c !important;
+}
+#cbi-openclash .CodeMirror-gutters {
+  border-right: 1px solid #3c3c3c !important;
+  background-color: #1e1e1e !important;
 }
 
 @supports (-webkit-backdrop-filter: none) or (backdrop-filter: none) {

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -239,6 +239,7 @@ table>tbody>tr>th,
 table>tfoot>tr>th,
 table>thead>tr>th {
   background-color: #252526;
+  border-top: none;
   border-bottom: black 1px solid !important;
 }
 

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -132,7 +132,7 @@ a:active {
   color: var(--dark_webkit-any-link);
 }
 
-a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a) {
+a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a, .cbi-button) {
   color: var(--dark_webkit-any-link) !important;
   text-shadow: 1px 1px 2px #000 !important;
 }

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -111,10 +111,6 @@ header::after {
   background-color: #252526 !important;
 }
 
-.main .main-left::-webkit-scrollbar-track {
-  background-color: #333;
-}
-
 .main .main-right {
   background-color: #1e1e1e;
 }

--- a/htdocs/luci-static/argon/js/color_calc-argon.js
+++ b/htdocs/luci-static/argon/js/color_calc-argon.js
@@ -1,4 +1,29 @@
 /*
+ *  The background color of the [Light Mode] subtabs follow the custom primary color and reduce its transparency
+ *  Author: SpeedPartner
+ */
+
+/*
+ *  Get hex for the [Light mode] Primary Color ,then reduce it to 25% transparency and convert it to RGBA value
+ */
+	const hexColor_primary_light = getComputedStyle(document.documentElement).getPropertyValue('--primary').replace(/\s/, "");
+	const hexToRgba_primary_light = (hex) => {
+  		const r = parseInt(hex.substring(1, 3), 16);
+  		const g = parseInt(hex.substring(3, 5), 16);
+  		const b = parseInt(hex.substring(5, 7), 16);
+  		const a = 0.15
+  		return [r, g, b].map(x => x.toFixed()).concat(a);
+	};
+	const rgbaColor_primary_light = hexToRgba_primary_light(hexColor_primary_light);
+	console.log(rgbaColor_primary_light);
+
+/*
+ *  Constitute a css color variable named light-subtabs-background
+ */
+	document.documentElement.style.setProperty('--light-subtabs-background', `rgba(`+rgbaColor_primary_light+`)`);
+
+
+/*
  *  Improved link font color that follows custom [Dark mode] Primary Color
  *  Author: SpeedPartner
  */

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1,4 +1,3 @@
-//  compress: false
 /**
  *  Argon is a clean HTML5 theme for LuCI. It is based on luci-theme-material and Argon Template
  *

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -325,6 +325,7 @@ li {
             max-width: 420px;
             background-color: #fff;
             background-color: var(--white);
+            overflow:hidden;
 
             .brand {
                 display: flex;
@@ -356,7 +357,7 @@ li {
                 overflow: hidden;
                 text-overflow: ellipsis;
                 display: -webkit-box;
-                -webkit-line-clamp: 3;
+                -webkit-line-clamp: 2;
                 -webkit-box-orient: vertical;
             }
 
@@ -3780,7 +3781,6 @@ input[name="nslookup"] {
         width: 100%;
 
         .login-form {
-            max-width: 480px;
 
             .form-login {
                 .input-group {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -208,7 +208,7 @@ a:active {
     text-decoration: none;
 }
 
-a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a) {
+a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a, .cbi-button) {
     color: -webkit-link;
     cursor: pointer;
     color: var(--primary);

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2482,7 +2482,7 @@ h3 {
     letter-spacing: 0.1rem;
     padding: 1rem 1.5rem;
     border-radius: 0.375rem;
-    background: #fff;
+    background: var(--lighter);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.03);
 }
 
@@ -3508,7 +3508,6 @@ input[name="nslookup"] {
     }
 
     h4 {
-        padding: 0.75rem 1.5rem;
         font-size: 0.7rem;
         font-weight: 600;
         color: #525f7f;
@@ -3613,7 +3612,7 @@ input[name="nslookup"] {
     display: block;
 }
 
-/* PassWall */
+/* luci-app-passwall */
 #cbi-passwall #add_link_div,
 #cbi-passwall #set_node_div {
     background: #fffffff0;
@@ -3626,6 +3625,30 @@ input[name="nslookup"] {
 }
 #cbi-passwall .cbi-section-table tbody ._now_use {
     background: #5e72e473 !important;
+}
+
+/* luci-app-commands */
+.commandbox h3 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.commandbox code {
+    word-break: break-word;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+div.commandbox {
+    height: 16em;
+}
+
+/* luci-app-ssr-plus */
+#cbi-shadowsocksr .cbi-map-descr h3 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 @media screen and (max-width: 1600px) {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1827,6 +1827,28 @@ td>table>tbody>tr>td,
     margin: 0;
 }
 
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+::-webkit-scrollbar,
+::-webkit-scrollbar-corner {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #9e9e9e;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #757575;
+}
+
+::-webkit-scrollbar-thumb:active {
+    background: #424242;
+}
+
 /* desc */
 
 
@@ -3673,30 +3695,6 @@ input[name="nslookup"] {
 
     .main>.main-left>.nav>.slide>.slide-menu>li>a {
         font-size: 0.7rem;
-    }
-}
-
-@media screen and (min-width: 600px) {
-    ::-webkit-scrollbar {
-        width: 10px;
-        height: 10px;
-    }
-
-    ::-webkit-scrollbar,
-    ::-webkit-scrollbar-corner {
-        background: transparent;
-    }
-
-    ::-webkit-scrollbar-thumb {
-        background: #9e9e9e;
-    }
-
-    ::-webkit-scrollbar-thumb:hover {
-        background: #757575;
-    }
-
-    ::-webkit-scrollbar-thumb:active {
-        background: #424242;
     }
 }
 

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -57,7 +57,7 @@
     --warning: #fb6340;
     --footer-color: #aaa;
     --menubar-background: #fff;
-    --menubar-scrollbar-thumb: #f6f9fc;
+    --menubar-scrollbar-thumb: #eee;
     --menubar-text-color: #4c4c4c;
     --blue: #5e72e4;
     --indigo: #5603ad;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1154,10 +1154,6 @@ form.inline+form.inline,
     border-color: var(--primary) !important;
 }
 
-.cbi-button-add {
-    margin-left: 1.5rem;
-}
-
 .node-services-vssr .ssr-button {
     margin-left: 0.3rem;
 

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -363,7 +363,7 @@ li {
             }
 
             .form-login {
-                width: 100%;
+                width: 420px;
                 padding: 20px 50px;
                 box-sizing: border-box;
 
@@ -3756,6 +3756,18 @@ input[name="nslookup"] {
     }
 
 
+}
+
+@media screen and (max-width: 500px) {
+.login-page {
+    .login-container {
+        margin-left: 0rem !important;
+        width: 500px;
+
+        .login-form {
+            max-width: 500px;
+        }
+    }
 }
 
 @media screen and (max-width: 480px) {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2721,7 +2721,7 @@ td>table>tbody>tr>td {
     }
 
     li {
-        background: #dce3e9;
+        background: #e3e3e3;
         display: inline-block;
         font-size: 0.875rem;
         border-top-left-radius: 0.25rem;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -179,6 +179,28 @@ body {
     color: var(--white);
 }
 
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+::-webkit-scrollbar,
+::-webkit-scrollbar-corner {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #9e9e9e;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #757575;
+}
+
+::-webkit-scrollbar-thumb:active {
+    background: #424242;
+}
+
 a:link,
 a:visited,
 a:active {
@@ -669,8 +691,7 @@ footer {
         }
 
         &::-webkit-scrollbar-track {
-            background-color: #fff;
-            background-color: var(--menubar-background);
+            background-color: transparent;
         }
 
         .sidenav-header {
@@ -1827,28 +1848,6 @@ td>table>tbody>tr>td,
     margin: 0;
 }
 
-::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-}
-
-::-webkit-scrollbar,
-::-webkit-scrollbar-corner {
-    background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-    background: #9e9e9e;
-}
-
-::-webkit-scrollbar-thumb:hover {
-    background: #757575;
-}
-
-::-webkit-scrollbar-thumb:active {
-    background: #424242;
-}
-
 /* desc */
 
 
@@ -2632,17 +2631,31 @@ td>table>tbody>tr>td {
     white-space: nowrap;
     overflow-x: auto;
 
+    .cbi-section::-webkit-scrollbar,
+    .cbi-section > *::-webkit-scrollbar {
+        width: 1px;
+        height: 5px;
+    }
+
     &::-webkit-scrollbar {
         width: 1px;
         height: 5px;
     }
 
     &::-webkit-scrollbar-thumb {
-        background-color: #f6f9fc
+        background-color: #9e9e9e;
+    }
+
+	&::-webkit-scrollbar-thumb:hover {
+        background-color: #757575;
+    }
+
+	&::-webkit-scrollbar-thumb:active {
+        background-color: #424242;
     }
 
     &::-webkit-scrollbar-track {
-        background-color: #fff;
+        background-color: transparent;
     }
 
     li[class~="active"],
@@ -2694,11 +2707,19 @@ td>table>tbody>tr>td {
     }
 
     &::-webkit-scrollbar-thumb {
-        background-color: #f6f9fc
+        background-color: #9e9e9e;
     }
 
-    &::-webkit-scrollbar-track {
-        background-color: #fff;
+    &::-webkit-scrollbar-thumb:hover {
+        background-color: #757575;
+    }
+
+    &::-webkit-scrollbar-thumb:active {
+        background-color: t#424242;
+    }
+
+	&::-webkit-scrollbar-track {
+        background-color: transparent;
     }
 
     li {
@@ -3889,13 +3910,9 @@ input[name="nslookup"] {
     }
 
 
-    .tabs,
-    .cbi-tabmenu {
-        &::-webkit-scrollbar {
-            width: 0px;
-            height: 0px;
-        }
-
+    ::-webkit-scrollbar {
+        width: 0px !important;
+        height: 0px  !important;
     }
 
 

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2536,6 +2536,8 @@ fieldset.cbi-section p {
     letter-spacing: 0.1rem;
     color: #32325d;
     font-weight: 600;
+    position: sticky;
+    left: 0;
 }
 
 table {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2629,7 +2629,7 @@ td>table>tbody>tr>td {
         border-bottom: 0.18751rem solid var(--primary);
         color: #5e72e4;
         color: var(--primary);
-        background-color: #dce1fe;
+        background-color: var(--light-subtabs-background);
         margin-bottom: 0;
         border-radius: 0;
 
@@ -2699,7 +2699,7 @@ td>table>tbody>tr>td {
             border-bottom: 0.18751rem solid var(--primary);
             color: #5e72e4;
             color: var(--primary);
-            background-color: #dce1fe;
+            background-color: var(--light-subtabs-background);
             margin-bottom: 0;
 
             a {
@@ -2712,7 +2712,7 @@ td>table>tbody>tr>td {
         border-bottom: 0.18751rem solid #5e72e4;
         border-bottom: 0.18751rem solid var(--primary);
         color: var(--primary);
-        background-color: #dce1fe;
+        background-color: var(--light-subtabs-background);
         margin-bottom: 0;
 
         a {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2629,14 +2629,8 @@ td>table>tbody>tr>td {
     white-space: nowrap;
     overflow-x: auto;
 
-    .cbi-section::-webkit-scrollbar,
-    .cbi-section > *::-webkit-scrollbar {
-        width: 1px;
-        height: 5px;
-    }
-
     &::-webkit-scrollbar {
-        width: 1px;
+        width: 5px;
         height: 5px;
     }
 
@@ -2690,6 +2684,12 @@ td>table>tbody>tr>td {
             border-bottom: 0.18751rem solid var(--primary);
         }
     }
+}
+
+.cbi-section::-webkit-scrollbar,
+.cbi-section > *::-webkit-scrollbar {
+    width: 5px;
+    height: 5px;
 }
 
 .cbi-tabmenu {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -677,6 +677,7 @@ footer {
         position: fixed;
         z-index: 100;
         transition: width 0.2s ease-in-out;
+        overflow-y: overlay;
 
         &::-webkit-scrollbar {
             width: 5px;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -263,7 +263,8 @@ li {
 
         video {
             width: 100%;
-            height: auto;
+            height: 100%;
+            object-fit: cover;
         }
     }
 
@@ -3767,13 +3768,6 @@ input[name="nslookup"] {
     .pull-right {
         float: right;
         margin-top: 0rem !important;
-    }
-
-    .login-page .video {
-        video {
-            width: auto !important;
-            height: 100% !important;
-        }
     }
 
     .login-page .login-container {

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -308,8 +308,8 @@ table>thead>tr>td {
 table>tbody>tr>th,
 table>tfoot>tr>th,
 table>thead>tr>th {
-
     background-color: #252526;
+    border-top: none;
     border-bottom: black 1px solid !important;
 }
 

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -602,7 +602,7 @@ td.cbi-value-field var,
 
 .node-services-vssr .block {
     background-color: #1e1e1e !important;
-    box-shadow: 0 0 0.5rem 0 rgba(0, 0, 0, .35);
+    box-shadow: 0 0 .5rem 0 rgba(0,0,0,0.35) !important;
 }
 
 .node-services-vssr .block h4 {
@@ -611,8 +611,8 @@ td.cbi-value-field var,
 
 .node-services-vssr .status-bar {
     color: #ccc;
-    box-shadow: 0 0 0.5rem 0 rgba(0, 0, 0, .35);
-    background-color: #1e1e1e;
+    background: #333333f0;
+    box-shadow: #00000094 10px 10px 30px 5px;
 }
 
 .node-services-vssr .cbi-section-table-row {
@@ -748,7 +748,7 @@ fieldset[id^="cbi-apply-"] {
     color: #ccc !important;
 }
 
-/* PassWall */
+/* luci-app-passwall */
 #cbi-passwall #add_link_div,
 #cbi-passwall #set_node_div {
     background: #333333f0 !important;
@@ -756,6 +756,44 @@ fieldset[id^="cbi-apply-"] {
 }
 #cbi-passwall #add_link_div #nodes_link {
     background: #3c3c3c  !important;
+}
+
+/* luci-app-bypass */
+#cbi-bypass .status-bar {
+    color: #ccc;
+    background: #333333f0;
+    box-shadow: #00000094 10px 10px 30px 5px;
+}
+
+/* luci-app-clash */
+#cbi-clash .cbi-section .pure-u-1-4 .pure-g,
+#cbi-clash .cbi-section .siz .pure-g {
+    background-color: #1e1e1e !important;
+    box-shadow: 0 0 .5rem 0 rgba(0,0,0,0.35) !important;
+}
+
+/* luci-app-openclash */
+#cbi-openclash #eye-icon,
+#cbi-openclash img[title="刷新"] {
+    filter: invert(100%);
+}
+#cbi-openclash #cbi-openclash-config fieldset[control-id="ControlID-46"],
+#cbi-openclash .CodeMirror-merge-copybuttons-right,
+.CodeMirror-scroll {
+    background-color: #333333 !important;
+}
+#cbi-openclash .cbi-section .cbi-tabmenu li {
+    border-right: 1px solid #3c3c3c !important;
+}
+#cbi-openclash .CodeMirror-merge {
+    border: 1px solid transparent !important;
+}
+#cbi-openclash-config-clog .cbi-section {
+    border: 1px solid #3c3c3c !important;
+}
+#cbi-openclash .CodeMirror-gutters {
+    border-right: 1px solid #3c3c3c !important;
+    background-color: #1e1e1e !important;
 }
 
 @supports (-webkit-backdrop-filter: none) or (backdrop-filter: none) {

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -174,9 +174,6 @@ header::after {
             background-color: #252526 !important;
         }
 
-        &::-webkit-scrollbar-track {
-            background-color: #333;
-        }
     }
 
     .main-right {

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -1,4 +1,3 @@
-//  compress: true
 /**
  *  Argon is a clean HTML5 theme for LuCI. It is based on luci-theme-material and Argon Template
  *

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -198,7 +198,7 @@ a:active {
     color: var(--dark_webkit-any-link);
 }
 
-a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a) {
+a:-webkit-any-link:not(li a, .main-left a, .brand, .pull-right a, .alert-message a, .login-container footer a, .cbi-button) {
     color: var(--dark_webkit-any-link) !important;
     text-shadow: 1px 1px 2px #000 !important;
 }

--- a/luasrc/view/themes/argon/footer.htm
+++ b/luasrc/view/themes/argon/footer.htm
@@ -59,25 +59,13 @@
 </div>
 </div>
 	<script>
-		// thanks for Jo-Philipp Wich <jow@openwrt.org>
-		var winHeight = $(window).height();
-		$(window).resize(function () {
-			if($(document.body).height() < 525 ){
-				if($(".ftc").css('display') != 'none'){
-					$(".ftc").hide()
-				}
-			}else{
-				if($(".ftc").css('display') == 'none'){
-					$(".ftc").show()
-				}
-			}
-		})
-	</script>
-
-	<script>
-		if (window.orientation == 90 || window.orientation == -90) {
-			$(".ftc").hide()
-		}
+		window.addEventListener('resize', function() {
+        		if (window.innerHeight < 600) {
+            			document.getElementsByClassName("ftc")[0].style.display = "none";
+        		} else {
+           			 document.getElementsByClassName("ftc")[0].style.display = "block";
+        		}
+    		})
 	</script>
 
 	<script src="<%=media%>/js/styles-argon.js<%# ?v=PKG_VERSION %>"></script>

--- a/luasrc/view/themes/argon/footer.htm
+++ b/luasrc/view/themes/argon/footer.htm
@@ -59,8 +59,14 @@
 </div>
 </div>
 	<script>
+        	if (window.innerHeight < 660) {
+            		document.getElementsByClassName("ftc")[0].style.display = "none";
+        	} else {
+           		 document.getElementsByClassName("ftc")[0].style.display = "block";
+        	}
+
 		window.addEventListener('resize', function() {
-        		if (window.innerHeight < 600) {
+        		if (window.innerHeight < 660) {
             			document.getElementsByClassName("ftc")[0].style.display = "none";
         		} else {
            			 document.getElementsByClassName("ftc")[0].style.display = "block";

--- a/luasrc/view/themes/argon/footer.htm
+++ b/luasrc/view/themes/argon/footer.htm
@@ -59,19 +59,19 @@
 </div>
 </div>
 	<script>
-        	if (window.innerHeight < 660) {
-            		document.getElementsByClassName("ftc")[0].style.display = "none";
-        	} else {
-           		 document.getElementsByClassName("ftc")[0].style.display = "block";
-        	}
+		if (window.innerHeight < 660) {
+			document.getElementsByClassName("ftc")[0].style.display = "none";
+		} else {
+			document.getElementsByClassName("ftc")[0].style.display = "block";
+		}
 
 		window.addEventListener('resize', function() {
-        		if (window.innerHeight < 660) {
-            			document.getElementsByClassName("ftc")[0].style.display = "none";
-        		} else {
-           			 document.getElementsByClassName("ftc")[0].style.display = "block";
-        		}
-    		})
+			if (window.innerHeight < 660) {
+				document.getElementsByClassName("ftc")[0].style.display = "none";
+			} else {
+				document.getElementsByClassName("ftc")[0].style.display = "block";
+			}
+		})
 	</script>
 
 	<script src="<%=media%>/js/styles-argon.js<%# ?v=PKG_VERSION %>"></script>

--- a/luasrc/view/themes/argon/header.htm
+++ b/luasrc/view/themes/argon/header.htm
@@ -267,7 +267,7 @@
 	<script src="<%=resource%>/cbi.js<%# ?v=PKG_VERSION %>"></script>
 	<script src="<%=resource%>/xhr.js<%# ?v=PKG_VERSION %>"></script>
 	<script src="<%=media%>/js/jquery.min.js?v=3.5.1"></script>
-	<script src="<%=media%>/js/dark-primary-font.js<%# ?v=PKG_VERSION %>"></script>
+	<script src="<%=media%>/js/color_calc-argon.js<%# ?v=PKG_VERSION %>"></script>
 </head>
 
 <body


### PR DESCRIPTION
- 修复 移动端 的 登录页面[sysauth] 因可拖动导致显示出模糊层以外的溢出区域,修复后该页面将不可拖动 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/7eb29a11b913f3da2ff715c13be7da1a25ccf128 https://github.com/jerrykuku/luci-theme-argon/issues/238
-重做footer自动隐藏,修复在浏览器刷新时,且窗口高度过小时,footer不会自动隐藏
-将 登录页面[sysauth] 中 主机名[brand-text] 的文本长度从原先的最长3行 改为 2行
-同时调整footer自动隐藏的窗口高度为<600,避免出现footer与其他元素重叠

- 重新改进footer自动隐藏的判断,并增加隐藏footer的最低高度,避免某些浏览器出现footer与其他元素重叠 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/12b3c8831ad9428f3aa082faf02b5e4fca793395

- 追加:[亮色模式] 下 子菜单选项卡[SubTabs]的背景颜色 可跟随 自定义主色调,背景颜色将降低其透明度到15% https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/23eaaf93ef1ecf26ea9b37dc24920f48955b8f99 https://github.com/jerrykuku/luci-theme-argon/issues/311

- 改进:在 登录页面[sysauth] 中,使用视频类型背景时,视频将保持同比例缩放以铺满整个页面 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/e1066bd6ba7884729bc8a165449a374f117b0037 https://github.com/jerrykuku/luci-theme-argon/issues/353

- 修复在缩小浏览器窗口时,主题滚动条样式可能丢失的问题 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/e093e7bfd2c63fdff818b44ff55ebbaa45e6bcbd

- 为 登录页面[sysauth] 适配windows系统下浏览器窗口缩放到最小宽度500px时的布局 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/99905fcab6e52400f45c0819ed78e3498dea8672

- 改进 滚动条[ScrollBar],并修复 子菜单选项卡[SubTabs] 和 表格[Table] 过长或者缩小浏览器窗口时,滚动条[ScrollBar] 显示异常 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/fd4d2f66886d8c19a4ba55e12ca8e1baa771f1f6 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/10400d0d1ddb283dd865177e64aaaeedf741fd74 https://github.com/jerrykuku/luci-theme-argon/issues/247

- 移除 添加按钮[ADD Button] 的 左侧外边距[margin-left] https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/4e87fa5f58554121578db89b6aba5845a1c4e726

- 修复 [暗色模式] 中 的某些情况下,表格顶部会出现白色边框线条 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/71052c797a2683c48aa47e301056218699696465

- 排除 所有 按钮[button] 的 文本阴影[text-shadow] https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/0ebcc4a0c625413edf3ecfeccac30b6e602be64c

- 适配 luci-app-commands luci-app-ssr-plus; https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/1d6cb628d3bf8f8b0aac0e4aa66e340e01fa7489
-[暗色模式]: luci-app-bypass luci-app-clash luci-app-openclash https://github.com/jerrykuku/luci-theme-argon/issues/341

- 改进:面板标题[panel-title] 不再随横向滚动条移动 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/4d6ecd5eb3a03240df0d40ca0b68c8dacf179365

- css 和 less 的编码格式统一改为 UTF-8 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/76ae30176b0c89cd5e883a057a3014bba7afab57

- 改进 左侧导航主菜单[main-left menu],避免出现 滚动条[ScrollBar] 时,菜单内元素向左侧挤压 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/fa1fcba07853545e807dfa43f9cc750b8be8b0b0

- 更改 [亮色模式] 下,左侧导航主菜单[main-left menu] 的 滚动条[ScrollBar] 颜色,以提升辨识度 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/e16233832c2129e2f4cd9a011561312070a85b63

- 改进 [亮色模式] 下,子菜单选项卡[SubTabs] 的背景颜色 https://github.com/jerrykuku/luci-theme-argon/pull/416/commits/bc0a610bf8e5db475e7e74c12ce03020f087e57b