### PR TITLE
18.06: Update to v1.8.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
 LUCI_DEPENDS:=+curl +jsonfilter
-PKG_VERSION:=1.8.1
-PKG_RELEASE:=20230527
+PKG_VERSION:=1.8.2
+PKG_RELEASE:=20230609
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,123 @@
-# luci-theme-argon ([中文](/README_ZH.md))
+<!-- markdownlint-configure-file {
+  "MD013": {
+    "code_blocks": false,
+    "tables": false,
+    "line_length":200
+  },
+  "MD033": false,
+  "MD041": false
+} -->
 
-[1]: https://img.shields.io/badge/license-MIT-brightgreen.svg
-[2]: /LICENSE
-[3]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg
-[4]: https://github.com/jerrykuku/luci-theme-argon/pulls
-[5]: https://img.shields.io/badge/Issues-welcome-brightgreen.svg
-[6]: https://github.com/jerrykuku/luci-theme-argon/issues/new
-[7]: https://img.shields.io/badge/release-v1.8.1-blue.svg?
-[8]: https://github.com/jerrykuku/luci-theme-argon/releases
-[9]: https://img.shields.io/github/downloads/jerrykuku/luci-theme-argon/total
-[10]: https://img.shields.io/badge/Contact-telegram-blue
-[11]: https://t.me/jerryk6
-[![license][1]][2]
-[![PRs Welcome][3]][4]
-[![Issue Welcome][5]][6]
-[![Release Version][7]][8]
-[![Release Count][9]][8]
-[![Contact Me][10]][11]
+[license]: /LICENSE
+[license-badge]: https://img.shields.io/github/license/jerrykuku/luci-theme-argon?style=flat-square&a=1
+[prs]: https://github.com/jerrykuku/luci-theme-argon/pulls
+[prs-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
+[issues]: https://github.com/jerrykuku/luci-theme-argon/issues/new
+[issues-badge]: https://img.shields.io/badge/Issues-welcome-brightgreen.svg?style=flat-square
+[release]: https://github.com/jerrykuku/luci-theme-argon/releases
+[release-badge]: https://img.shields.io/badge/release-v1.8.2-blue.svg?
+[download]: https://github.com/jerrykuku/luci-theme-argon/releases
+[download-badge]: https://img.shields.io/github/downloads/jerrykuku/luci-theme-argon/total?style=flat-square
+[contact]: https://t.me/jerryk6
+[contact-badge]: https://img.shields.io/badge/Contact-telegram-blue?style=flat-square
+[en-us-link]: /README.md
+[zh-cn-link]: /README_ZH.md
+[en-us-release-log]: /RELEASE.md
+[zh-cn-release-log]: /RELEASE_ZH.md
+[config-link]: https://github.com/jerrykuku/luci-app-argon-config/releases
+[lede]: https://github.com/coolsnowwolf/lede
+[official]: https://github.com/openwrt/openwrt
+[immortalwrt]: https://github.com/immortalwrt/immortalwrt
 
-![](/Screenshots/screenshot_pc.jpg)
-![](/Screenshots/screenshot_phone.jpg)
+<div align="center">
+<img src="https://raw.githubusercontent.com/jerrykuku/staff/master/argon_title2.svg">
 
-A new Luci theme for LEDE/OpenWRT  
-Argon is a clean HTML5 theme for LuCI. It is based on luci-theme-material and Argon Template  
+# A brand new OpenWrt LuCI theme
+### • This branch only matches Lean's LEDE / OpenWrt LuCI 18.06 •
+  
+Argon is **a clean and tidy OpenWrt LuCI theme** that allows<br/>
+users to customize their login interface with images or videos.  
+It also supports automatic and manual switching between light and dark modes.
+
+[![license][license-badge]][license]
+[![prs][prs-badge]][prs]
+[![issues][issues-badge]][issues]
+[![release][release-badge]][release]
+[![download][download-badge]][download]
+[![contact][contact-badge]][contact]
+
+**English** |
+[简体中文][zh-cn-link]
+
+[Key Features](#key-features) •
+[Getting started](#getting-started) •
+[Screenshots](#screenshots) •
+[Contributors](#contributors) •
+[Credits](#credits)
+
+<img src="https://raw.githubusercontent.com/jerrykuku/staff/master/argon2.gif">
+</div>
+
+## Key Features
+
+- Clean Layout.
+- Adapted to mobile display.
+- Customizable theme colors.
+- Support for using Bing images as login background.
+- Support for custom uploading of images or videos as login background.
+- Automatically switch between light and dark modes with the system, and can also be set to a fixed mode.
+- Settings plugin with extensions [luci-app-argon-config][config-link]
 
 ## Notice
+- Chrome & Edge browser is highly recommended. There are some new css3 features used in this theme, currently only Chrome & Edge has the best compatibility.
+- FireFox does not enable the backdrop-filter by default, [see here](https://developer.mozilla.org/zh-CN/docs/Web/CSS/backdrop-filter) for the opening method.
 
-This branch only matches lean openwrt LuCI 18.06.
+## Getting started
 
-## How to build
+### Build for Lean's LEDE project
 
-Enter in your openwrt/package/lean or other
-
-### Lean lede
-
-```
-cd lede/package/lean  
-rm -rf luci-theme-argon  
-git clone -b 18.06 https://github.com/jerrykuku/luci-theme-argon.git  
-make menuconfig #choose LUCI->Theme->Luci-theme-argon  
-make -j1 V=s  
+```bash
+cd lede/package/lean
+rm -rf luci-theme-argon
+git clone -b 18.06 https://github.com/jerrykuku/luci-theme-argon.git luci-theme-argon
+make menuconfig #choose LUCI->Theme->Luci-theme-argon
+make -j1 V=s
 ```
 
-## Install
+### Install on LuCI 18.06 ( Lean's LEDE )
 
-### For Lean openwrt 18.06 LuCI
-
-```
-wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.1/luci-theme-argon_1.8.1-20230527_all.ipk
+```bash
+wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.2/luci-theme-argon_1.8.2-20230609_all.ipk
 opkg install luci-theme-argon*.ipk
 ```
 
-## Thanks to
+### Install luci-app-argon-config
 
-luci-theme-material: https://github.com/LuttyYang/luci-theme-material/
+```bash
+wget --no-check-certificate https://github.com/jerrykuku/luci-app-argon-config/releases/download/v0.9/luci-app-argon-config_0.9_all.ipk
+opkg install luci-app-argon-config*.ipk
+```
+
+## Screenshots
+
+![desktop](/Screenshots/screenshot_pc.jpg)
+![mobile](/Screenshots/screenshot_phone.jpg)
+
+## Contributors
+
+<a href="https://github.com/jerrykuku/luci-theme-argon/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=jerrykuku/luci-theme-argon" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+
+## Related Projects
+
+- [luci-app-argon-config](https://github.com/jerrykuku/luci-app-argon-config): Argon theme config plugin
+- [luci-app-vssr](https://github.com/jerrykuku/luci-app-vssr): An OpenWrt internet surfing plugin
+- [openwrt-package](https://github.com/jerrykuku/openwrt-package): My OpenWrt package
+- [CasaOS](https://github.com/IceWhaleTech/CasaOS): A simple, easy-to-use, elegant open-source Personal Cloud system (My current main project)
+
+## Credits
+
+[luci-theme-material](https://github.com/LuttyYang/luci-theme-material/)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,100 +1,124 @@
-# luci-theme-argon ([English](/README.md))
-[1]: https://img.shields.io/badge/license-MIT-brightgreen.svg
-[2]: /LICENSE
-[3]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg
-[4]: https://github.com/jerrykuku/luci-theme-argon/pulls
-[5]: https://img.shields.io/badge/Issues-welcome-brightgreen.svg
-[6]: https://github.com/jerrykuku/luci-theme-argon/issues/new
-[7]: https://img.shields.io/badge/release-v1.7.7-blue.svg?
-[8]: https://github.com/jerrykuku/luci-theme-argon/releases
-[9]: https://img.shields.io/github/downloads/jerrykuku/luci-theme-argon/total
-[10]: https://img.shields.io/badge/Contact-telegram-blue
-[11]: https://t.me/jerryk6
-[![license][1]][2]
-[![PRs Welcome][3]][4]
-[![Issue Welcome][5]][6]
-[![Release Version][7]][8]
-[![Release Count][9]][8]
-[![Contact Me][10]][11]
+<!-- markdownlint-configure-file {
+  "MD013": {
+    "code_blocks": false,
+    "tables": false,
+    "line_length":200
+  },
+  "MD033": false,
+  "MD041": false
+} -->
 
-![](/Screenshots/screenshot_pc.jpg)
-![](/Screenshots/screenshot_phone.jpg)
+[license]: /LICENSE
+[license-badge]: https://img.shields.io/github/license/jerrykuku/luci-theme-argon?style=flat-square&a=1
+[prs]: https://github.com/jerrykuku/luci-theme-argon/pulls
+[prs-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
+[issues]: https://github.com/jerrykuku/luci-theme-argon/issues/new
+[issues-badge]: https://img.shields.io/badge/Issues-welcome-brightgreen.svg?style=flat-square
+[release]: https://github.com/jerrykuku/luci-theme-argon/releases
+[release-badge]: https://img.shields.io/badge/release-v1.8.2-blue.svg?
+[download]: https://github.com/jerrykuku/luci-theme-argon/releases
+[download-badge]: https://img.shields.io/github/downloads/jerrykuku/luci-theme-argon/total?style=flat-square
+[contact]: https://t.me/jerryk6
+[contact-badge]: https://img.shields.io/badge/Contact-telegram-blue?style=flat-square
+[en-us-link]: /README.md
+[zh-cn-link]: /README_ZH.md
+[en-us-release-log]: /RELEASE.md
+[zh-cn-release-log]: /RELEASE_ZH.md
+[config-link]: https://github.com/jerrykuku/luci-app-argon-config/releases
+[lede]: https://github.com/coolsnowwolf/lede
+[official]: https://github.com/openwrt/openwrt
+[immortalwrt]: https://github.com/immortalwrt/immortalwrt
 
-全新的 Openwrt 主题，基于luci-theme-material 和 开源免费的 Argon 模板进行移植。 
+<div align="center">
+<img src="https://raw.githubusercontent.com/jerrykuku/staff/master/argon_title2.svg">
+
+# 一个全新的 OpenWrt 主题
+### • 该分支只适配 Lean's LEDE 和 OpenWrt LuCI 18.06 •
+  
+Argon 是**一款干净整洁的 OpenWrt LuCI 主题**，  
+允许用户使用图片或视频自定义其登录界面。  
+它还支持在浅色模式和深色模式之间自动或手动切换。
+
+[![license][license-badge]][license]
+[![prs][prs-badge]][prs]
+[![issues][issues-badge]][issues]
+[![release][release-badge]][release]
+[![download][download-badge]][download]
+[![contact][contact-badge]][contact]
+
+[English][en-us-link] |
+**简体中文**
+
+[特色](#特色) •
+[快速开始](#快速开始) •
+[屏幕截图](#屏幕截图) •
+[贡献者](#贡献者) •
+[鸣谢](#鸣谢)
+
+<img src="https://raw.githubusercontent.com/jerrykuku/staff/master/argon2.gif">
+</div>
+
+## 特色
+
+- 干净整洁的布局。
+- 适配移动端显示。
+- 可自定义主题颜色。
+- 支持使用 Bing 图片作为登录背景。
+- 支持自定义上传图片或视频作为登录背景。
+- 通过系统自动在明暗模式之间切换，也可设置为固定模式。
+- 带有扩展功能的设置插件 [luci-app-argon-config][config-link]
 
 ## 注意
 
-当前master版本基于官方 OpenWrt 19.07.1 稳定版固件进行移植适配。  
-v2.x.x 适配官方主线快照版本。  
-v1.x.x 适配18.06 和 Lean Openwrt [如果你是lean代码 请选择这个版本]
+- 强烈建议使用 Chrome 和 Edge 浏览器。该主题中使用了一些新的 css3 功能，目前只有 Chrome 和 Edge 浏览器有最好的兼容性。
+- FireFox 默认不启用 backdrop-filter，[见这里](https://developer.mozilla.org/zh-CN/docs/Web/CSS/backdrop-filter)的打开方法。
 
-## 更新日志 2023.04.04 [18.06] V1.7.7
+## 快速开始
 
-- 【v1.7.3】修复访问状态/防火墙页面时，左边导航长时间无响应问题。
-- 【v1.7.3】修复当bing壁纸获取失败时，导致登录页面无法访问的问题。
-- 【v1.7.2】由于访问bing api需要路由器有稳定的网络，故将bing api修改为可选项，默认为内置壁纸显示，登录后进入argon-config【新版】进行修改。
-- 【v1.7.2】修复了一个内置交换机无法显示接口图标和速率的问题。
-- 【v1.7.1】修复登录页面在极小分辨率下底部文字会遮挡按钮的问题.
-- 【v1.7.1】增加获取bing api的超时时间，以解决网速慢时长时间获取不到返回的问题.
-- 【v1.7.1】调整了一些样式.
-- 【v1.7.1】给进度条增加了一个动画效果.
-- 【v1.7.0】修复暗色模式下部分颜色错误.
-- 【v1.7.0】当随固件编译时，将自动设置为默认主题.
-- 【v1.7.0】修改文件结构，以适应luci-app-argon-config.
-- 【v1.6.9】修复了在某些手机下图片背景第一次加载不能显示的问题。
-- 【v1.6.9】修改系统和内核日志的背景颜色为白色。
-- 【v1.6.9】取消 luasocket 的依赖，无需再担心依赖问题。
-- 【v1.6.8】去掉了对wget的依赖，默认是用luasocket,为避免更新出错，请提前opkg install luasocket。
-- 【v1.6.8】更新了图标库，为未定义的菜单增加了一个默认的图标。
-- 【v1.6.6】背景文件策略调整为，同时接受 jpg png gif mp4, 图片和视频同时随机。
-- 【v1.6.6】视频背景加了一个音量开关，喜欢带声音的可以自行点击开启，默认为静音模式。
-- 【v1.6.6】修复了手机模式下，登录页面出现键盘时，文字覆盖按钮的问题。
-- 【v1.6.6】修正了暗黑模式下下拉选项的背景颜色，同时修改了滚动条的样式。
-- 【v1.6.6】jquery 更新到 v3.5.1。
-- 【v1.6.4】增加可自定义登录背景功能，请自行将文件上传到/www/luci-static/argon/background 目录下，支持jpg png gif格式图片，主题将会优先显示自定义背景，多个背景为随机显示，系统默认依然为从bing获取。
-- 【v1.6.4】增加了可以强制锁定暗色模式的功能，如果需要，请登录ssh 输入：touch /etc/dark 即可开启，关闭请输入：rm -rf /etc/dark，关闭后颜色模式为跟随系统。
-- 【v1.6.4】修改了底部argon版本的获取方式，以后将自动根据ipk版本显示。
-- 【v1.6.4】修正了一些文字的颜色。
-- 【v1.6.3】登录背景添加毛玻璃效果。
-- 【v1.6.1】全新的登录界面,图片背景跟随Bing.com，每天自动切换。
-- 【v1.6.1】全新的主题icon。
-- 【v1.6.1】增加多个导航icon。
-- 【v1.6.1】细致的微调了 字号大小边距等等。
-- 【v1.6.1】重构了css文件。
-- 【v1.6.1】自动适应的暗黑模式。
+### 使用 Lean's LEDE 构建
 
-## 如何编译
-
-进入 openwrt/package/lean  或者其他目录
-
-### Lean 源码
-
-```
-cd lede/package/lean  
-rm -rf luci-theme-argon  
-git clone -b 18.06 https://github.com/jerrykuku/luci-theme-argon.git  
-make menuconfig #choose LUCI->Theme->Luci-theme-argon  
-make -j1 V=s  
+```bash
+cd lede/package/lean
+rm -rf luci-theme-argon
+git clone -b 18.06 https://github.com/jerrykuku/luci-theme-argon.git luci-theme-argon
+make menuconfig #choose LUCI->Theme->Luci-theme-argon
+make -j1 V=s
 ```
 
-### Openwrt 官方源码
+### 在 18.06 的 LuCI 上安装 ( Lean's LEDE )
 
-```
-cd openwrt/package
-git clone https://github.com/jerrykuku/luci-theme-argon.git  
-make menuconfig #choose LUCI->Theme->Luci-theme-argon  
-make -j1 V=s  
-```
-
-## 如何安装
-
-### Lean openwrt 18.06 LuCI
-
-```
-wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.7.0/luci-theme-argon_1.7.0-20200908_all.ipk
+```bash
+wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.2/luci-theme-argon_1.8.2-20230609_all.ipk
 opkg install luci-theme-argon*.ipk
 ```
 
-## 感谢
+### 安装 luci-app-argon-config
 
-luci-theme-material: https://github.com/LuttyYang/luci-theme-material/
+```bash
+wget --no-check-certificate https://github.com/jerrykuku/luci-app-argon-config/releases/download/v0.9/luci-app-argon-config_0.9_all.ipk
+opkg install luci-app-argon-config*.ipk
+```
+
+## 屏幕截图
+
+![desktop](/Screenshots/screenshot_pc.jpg)
+![mobile](/Screenshots/screenshot_phone.jpg)
+
+## 贡献者
+
+<a href="https://github.com/jerrykuku/luci-theme-argon/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=jerrykuku/luci-theme-argon" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+
+## 相关项目
+
+- [luci-app-argon-config](https://github.com/jerrykuku/luci-app-argon-config): Argon 主题的设置插件
+- [luci-app-vssr](https://github.com/jerrykuku/luci-app-vssr): 一个 OpenWrt 的互联网冲浪插件
+- [openwrt-package](https://github.com/jerrykuku/openwrt-package): 我的 OpenWrt Package
+- [CasaOS](https://github.com/IceWhaleTech/CasaOS): 一个简单、易用且优雅的开源个人家庭云系统（我目前主要开发的项目）
+
+## 鸣谢
+
+[luci-theme-material](https://github.com/LuttyYang/luci-theme-material/)

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1034,7 +1034,7 @@ select {
 }
 /*textarea*/
 textarea {
-  border: none !important;
+  border: 1px solid #dee2e6 !important;
   outline: none;
   min-height: 14rem !important;
   padding: 0.8rem !important;
@@ -1042,6 +1042,9 @@ textarea {
   font-family: var(--font-family-monospace) !important;
   font-size: inherit;
   color: black;
+  box-shadow: inset 0 1px 3px rgb(124 124 124 / 30%);
+  border-radius: 0.375rem !important;
+  vertical-align: middle;
 }
 /* change */
 .uci-change-list {
@@ -2946,12 +2949,6 @@ input[name="nslookup"] {
 #cbi-passwall #add_link_div,
 #cbi-passwall #set_node_div {
   background: #fffffff0;
-}
-#cbi-passwall #add_link_div #nodes_link {
-  background: var(--lighter);
-}
-#cbi-passwall #add_link_div .cbi-value-title {
-  vertical-align: middle;
 }
 #cbi-passwall .cbi-section-table tbody ._now_use {
   background: #5e72e473 !important;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2978,6 +2978,10 @@ div.commandbox {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* luci-app-mwan3 */
+.node-status-mwan .cbi-tabmenu {
+  padding: 3rem 0.5rem 0 0.5rem;
+}
 @media screen and (max-width: 1600px) {
   .main .main-left {
     width: calc(0% + 13rem);

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2172,7 +2172,8 @@ td > table > tbody > tr > td {
 }
 .tabs::-webkit-scrollbar,
 .cbi-section::-webkit-scrollbar,
-.cbi-section > *::-webkit-scrollbar {
+.cbi-section > *::-webkit-scrollbar,
+textarea::-webkit-scrollbar {
   width: 5px;
   height: 5px;
 }

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -575,7 +575,7 @@ footer a {
   position: fixed;
   z-index: 100;
   transition: width 0.2s ease-in-out;
-  overflow-y: overlay;
+  overflow-y: scroll;
 }
 .main .main-left::-webkit-scrollbar {
   width: 5px;

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -452,8 +452,10 @@ select {
 
 /*textarea for dark mode*/
 textarea {
+  border: 1px solid #3c3c3c !important;
   background-color: #1e1e1e;
   color: #ccc;
+  box-shadow: inset 0 1px 3px rgb(0 0 0 / 30%);
 }
 
 .cbi-section-remove:nth-of-type(2n),
@@ -680,9 +682,6 @@ fieldset[id^="cbi-apply-"] {
 #cbi-passwall #set_node_div {
   background: #333333f0 !important;
   box-shadow: #00000094 10px 10px 30px 5px !important;
-}
-#cbi-passwall #add_link_div #nodes_link {
-  background: #3c3c3c  !important;
 }
 
 /* luci-app-bypass */

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1234,7 +1234,7 @@ select {
 
 /*textarea*/
 textarea {
-    border: none !important;
+    border: 1px solid #dee2e6 !important;
     outline: none;
     min-height: 14rem !important;
     padding: 0.8rem !important;
@@ -1242,6 +1242,9 @@ textarea {
     font-family: var(--font-family-monospace) !important;
     font-size: inherit;
     color: black;
+    box-shadow: inset 0 1px 3px rgb(124 124 124 / 30%);
+    border-radius: 0.375rem !important;
+    vertical-align: middle;
 }
 
 /* change */
@@ -3619,12 +3622,6 @@ input[name="nslookup"] {
 #cbi-passwall #add_link_div,
 #cbi-passwall #set_node_div {
     background: #fffffff0;
-}
-#cbi-passwall #add_link_div #nodes_link {
-    background: var(--lighter);
-}
-#cbi-passwall #add_link_div .cbi-value-title {
-    vertical-align: middle;
 }
 #cbi-passwall .cbi-section-table tbody ._now_use {
     background: #5e72e473 !important;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3654,6 +3654,11 @@ div.commandbox {
     white-space: nowrap;
 }
 
+/* luci-app-mwan3 */
+.node-status-mwan .cbi-tabmenu {
+    padding: 3rem 0.5rem 0 0.5rem;
+}
+
 @media screen and (max-width: 1600px) {
 
     .main {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -677,7 +677,7 @@ footer {
         position: fixed;
         z-index: 100;
         transition: width 0.2s ease-in-out;
-        overflow-y: overlay;
+        overflow-y: scroll;
 
         &::-webkit-scrollbar {
             width: 5px;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2687,7 +2687,8 @@ td>table>tbody>tr>td {
 }
 
 .cbi-section::-webkit-scrollbar,
-.cbi-section > *::-webkit-scrollbar {
+.cbi-section > *::-webkit-scrollbar,
+textarea::-webkit-scrollbar {
     width: 5px;
     height: 5px;
 }

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -521,8 +521,10 @@ select {
 
 /*textarea for dark mode*/
 textarea {
+    border: 1px solid #3c3c3c !important;
     background-color: #1e1e1e;
     color: #ccc;
+    box-shadow: inset 0 1px 3px rgb(0 0 0 / 30%);
 }
 
 .cbi-section-remove:nth-of-type(2n),
@@ -752,9 +754,6 @@ fieldset[id^="cbi-apply-"] {
 #cbi-passwall #set_node_div {
     background: #333333f0 !important;
     box-shadow: #00000094 10px 10px 30px 5px !important;
-}
-#cbi-passwall #add_link_div #nodes_link {
-    background: #3c3c3c  !important;
 }
 
 /* luci-app-bypass */

--- a/luasrc/view/themes/argon/footer.htm
+++ b/luasrc/view/themes/argon/footer.htm
@@ -41,9 +41,9 @@
 </div>
 <footer>
 	<div class="ftc">
-		<a class="luci-link" href="https://github.com/openwrt/luci">Powered by <%= ver.luciname %>
+		<a class="luci-link" href="https://github.com/openwrt/luci" target="_blank">Powered by <%= ver.luciname %>
 			(<%= ver.luciversion %>)</a> /
-		<a href="https://github.com/jerrykuku/luci-theme-argon">ArgonTheme <%# vPKG_VERSION %></a> /
+		<a href="https://github.com/jerrykuku/luci-theme-argon" target="_blank">ArgonTheme <%# vPKG_VERSION %></a> /
 		<%= ver.distversion %>
 		<% if #categories > 1 then %>
 		<ul class="breadcrumb pull-right" id="modemenu">


### PR DESCRIPTION
- 改进: **_页脚[footer]_** 中的 **_链接[link]_** 使用新标签页打开 https://github.com/jerrykuku/luci-theme-argon/pull/420/commits/828c36bd557ce57bbde1138b0ba2af2335e7293b

- 补充:缩小 所有 **_textarea_** 的 **_滚动条[ScrollBar]_** 大小 https://github.com/jerrykuku/luci-theme-argon/pull/420/commits/d0d767827160432acb00aec0119e4c901a5704ce

- 改进/修复 **_均衡负载[luci-app-mwan3]_** 中 **_状态[Load Banlancing]_** 的 **_子菜单选项卡[SubTabs]_** 的位置 https://github.com/jerrykuku/luci-theme-argon/pull/420/commits/bb0f3759fed9ed25ad15a25f36a380febd07ec0c https://github.com/jerrykuku/luci-theme-argon/issues/419

- 新增/改进: 为 **_textarea_** 增加 边框&内部阴影,并将其设置为垂直居中 https://github.com/jerrykuku/luci-theme-argon/pull/420/commits/79dbe0b2b3c15b5b44ec226096b4c56da172b470 https://github.com/jerrykuku/luci-theme-argon/issues/418

- 重做:将 **_左侧导航主菜单[main-left menu]_** 的 overflow-y 改为 scroll;避免出现 **_滚动条[ScrollBar]_** 时,菜单内元素向左侧挤压 https://github.com/jerrykuku/luci-theme-argon/pull/420/commits/c27b68ad68314398a417c46a23518baed74e7855