### PR TITLE
18.06 lede样式调整

### DIFF
--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2903,10 +2903,10 @@ input[name="nslookup"] {
 .node-system-flashops fieldset {
   margin-top: 0;
 }
-.node-system-flashops fieldset > ul{
+.node-system-flashops fieldset > ul {
   padding: 1rem;
 }
-.node-system-flashops fieldset + .cbi-page-actions{
+.node-system-flashops fieldset + .cbi-page-actions {
   margin-top: 1rem;
 }
 .node-status-iptables .cbi-tabmenu,
@@ -2988,13 +2988,13 @@ div.commandbox {
   padding: 3rem 0.5rem 0 0.5rem;
 }
 /* luci-app-openclash */
-.node-services-openclash .cbi-tabmenu{
+.node-services-openclash .cbi-tabmenu {
   font-size: 0;
 }
-.node-services-openclash .cbi-tabmenu > li{
+.node-services-openclash .cbi-tabmenu > li {
   margin-right: 4px;
 }
-.node-services-openclash .cbi-tabmenu > li:last-child{
+.node-services-openclash .cbi-tabmenu > li:last-child {
   margin-right: 0;
 }
 

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1045,6 +1045,9 @@ textarea {
   border-radius: 0.375rem !important;
   vertical-align: middle;
 }
+.cbi-value .cbi-value-field textarea {
+  margin: 0.25rem;
+}
 /* change */
 .uci-change-list {
   font-family: monospace;

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1042,7 +1042,6 @@ textarea {
   font-family: var(--font-family-monospace) !important;
   font-size: inherit;
   color: black;
-  box-shadow: inset 0 1px 3px rgb(124 124 124 / 30%);
   border-radius: 0.375rem !important;
   vertical-align: middle;
 }

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2900,6 +2900,12 @@ input[name="nslookup"] {
 .node-system-flashops fieldset {
   margin-top: 0;
 }
+.node-system-flashops fieldset > ul{
+  padding: 1rem;
+}
+.node-system-flashops fieldset + .cbi-page-actions{
+  margin-top: 1rem;
+}
 .node-status-iptables .cbi-tabmenu,
 .node-system-packages .cbi-tabmenu,
 .node-system-flashops .cbi-tabmenu {
@@ -2978,6 +2984,17 @@ div.commandbox {
 .node-status-mwan .cbi-tabmenu {
   padding: 3rem 0.5rem 0 0.5rem;
 }
+/* luci-app-openclash */
+.node-services-openclash .cbi-tabmenu{
+  font-size: 0;
+}
+.node-services-openclash .cbi-tabmenu > li{
+  margin-right: 4px;
+}
+.node-services-openclash .cbi-tabmenu > li:last-child{
+  margin-right: 0;
+}
+
 @media screen and (max-width: 1600px) {
   .main .main-left {
     width: calc(0% + 13rem);

--- a/htdocs/luci-static/argon/css/dark.css
+++ b/htdocs/luci-static/argon/css/dark.css
@@ -455,7 +455,6 @@ textarea {
   border: 1px solid #3c3c3c !important;
   background-color: #1e1e1e;
   color: #ccc;
-  box-shadow: inset 0 1px 3px rgb(0 0 0 / 30%);
 }
 
 .cbi-section-remove:nth-of-type(2n),

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1242,7 +1242,6 @@ textarea {
     font-family: var(--font-family-monospace) !important;
     font-size: inherit;
     color: black;
-    box-shadow: inset 0 1px 3px rgb(124 124 124 / 30%);
     border-radius: 0.375rem !important;
     vertical-align: middle;
 }

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3555,6 +3555,14 @@ input[name="nslookup"] {
     margin-top: 0;
 }
 
+.node-system-flashops fieldset > ul{
+    padding: 1rem;
+}
+
+.node-system-flashops fieldset + .cbi-page-actions{
+    margin-top: 1rem;
+}
+
 .node-status-iptables .cbi-tabmenu,
 .node-system-packages .cbi-tabmenu,
 .node-system-flashops .cbi-tabmenu {
@@ -3653,6 +3661,17 @@ div.commandbox {
 /* luci-app-mwan3 */
 .node-status-mwan .cbi-tabmenu {
     padding: 3rem 0.5rem 0 0.5rem;
+}
+
+/* luci-app-openclash */
+.node-services-openclash .cbi-tabmenu{
+    font-size: 0;
+}
+.node-services-openclash .cbi-tabmenu > li {
+    margin-right: 4px;
+}
+.node-services-openclash .cbi-tabmenu > li:last-child{
+    margin-right: 0;
 }
 
 @media screen and (max-width: 1600px) {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3559,11 +3559,11 @@ input[name="nslookup"] {
     margin-top: 0;
 }
 
-.node-system-flashops fieldset > ul{
+.node-system-flashops fieldset > ul {
     padding: 1rem;
 }
 
-.node-system-flashops fieldset + .cbi-page-actions{
+.node-system-flashops fieldset + .cbi-page-actions {
     margin-top: 1rem;
 }
 
@@ -3668,13 +3668,13 @@ div.commandbox {
 }
 
 /* luci-app-openclash */
-.node-services-openclash .cbi-tabmenu{
+.node-services-openclash .cbi-tabmenu {
     font-size: 0;
 }
 .node-services-openclash .cbi-tabmenu > li {
     margin-right: 4px;
 }
-.node-services-openclash .cbi-tabmenu > li:last-child{
+.node-services-openclash .cbi-tabmenu > li:last-child {
     margin-right: 0;
 }
 

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1246,6 +1246,10 @@ textarea {
     vertical-align: middle;
 }
 
+.cbi-value .cbi-value-field textarea {
+    margin: 0.25rem;
+}
+
 /* change */
 .uci-change-list {
     font-family: monospace;

--- a/htdocs/luci-static/argon/less/dark.less
+++ b/htdocs/luci-static/argon/less/dark.less
@@ -524,7 +524,6 @@ textarea {
     border: 1px solid #3c3c3c !important;
     background-color: #1e1e1e;
     color: #ccc;
-    box-shadow: inset 0 1px 3px rgb(0 0 0 / 30%);
 }
 
 .cbi-section-remove:nth-of-type(2n),


### PR DESCRIPTION
+ 修复openclash不同页面的tab间距不一致问题
+ 移除textarea的阴影 #425 
+ 优化 刷写固件-验证 页面校验信息显示效果 #426 