### PR TITLE
18.06分支 更新到 v1.8.4 - EOL

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,10 +4,10 @@
 #
 
 #
-# Fork 和 compile the latest version yourself using Github Actions
+# Fork and compile the latest version yourself using Github Actions
 #   1.Into the repository of your own fork
 #   2.Into the repository [Settings]
-# 3.[Code 和 automation - Actions] ↓ [General] → [Workflow permissions] ↓ Check the [Read 和 write permissions] 和 [Save]
+# 3.[Code and automation - Actions] ↓ [General] → [Workflow permissions] ↓ Check the [Read 和 write permissions] and [Save]
 #   4.Let's take [Actions]
 #
 
@@ -19,7 +19,7 @@ on:
       ssh:
         description: 'SSH connection to Actions'
         required: false
-        默认: 'false'
+        default: 'false'
   push:
     branches:
       - '18.06'

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,10 +4,10 @@
 #
 
 #
-# Fork and compile the latest version yourself using Github Actions
+# Fork 和 compile the latest version yourself using Github Actions
 #   1.Into the repository of your own fork
 #   2.Into the repository [Settings]
-#   3.[Code and automation - Actions] ↓ [General] → [Workflow permissions] ↓  Check the [Read and write permissions] and [Save]
+# 3.[Code 和 automation - Actions] ↓ [General] → [Workflow permissions] ↓ Check the [Read 和 write permissions] 和 [Save]
 #   4.Let's take [Actions]
 #
 
@@ -19,7 +19,7 @@ on:
       ssh:
         description: 'SSH connection to Actions'
         required: false
-        default: 'false'
+        默认: 'false'
   push:
     branches:
       - '18.06'
@@ -32,7 +32,7 @@ jobs:
   job_check:
     if: github.repository == ${{ github.repository }}
     name: Check Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       argon_version: ${{ steps.check_version.outputs.latest_version }}
       has_update: ${{ steps.check_version.outputs.has_update }}
@@ -70,7 +70,7 @@ jobs:
     name: Build Argon (18.06)
     needs: job_check
     if: needs.job_check.outputs.has_update == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install packages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
 LUCI_DEPENDS:=+curl +jsonfilter
-PKG_VERSION:=1.8.3
-PKG_RELEASE:=20230710
+PKG_VERSION:=1.8.4
+PKG_RELEASE:=20241221
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [issues]: https://github.com/jerrykuku/luci-theme-argon/issues/new
 [issues-badge]: https://img.shields.io/badge/Issues-welcome-brightgreen.svg?style=flat-square
 [release]: https://github.com/jerrykuku/luci-theme-argon/releases
-[release-badge]: https://img.shields.io/badge/release-v1.8.3-blue.svg?
+[release-badge]: https://img.shields.io/badge/release-v1.8.4-blue.svg?
 [download]: https://github.com/jerrykuku/luci-theme-argon/releases
 [download-badge]: https://img.shields.io/github/downloads/jerrykuku/luci-theme-argon/total?style=flat-square
 [contact]: https://t.me/jerryk6
@@ -33,7 +33,7 @@
 <img src="https://raw.githubusercontent.com/jerrykuku/staff/master/argon_title4.svg">
 
 # A brand new OpenWrt LuCI theme
-### • This branch only matches [Lean's LEDE][lede] / [OpenWrt LuCI 18.06][official-luci-18.06] •
+### • This branch only matches [Lean's LEDE ( LuCI 18.06 )][lede] / [OpenWrt LuCI 18.06][official-luci-18.06] •
   
 Argon is **a clean and tidy OpenWrt LuCI theme** that allows<br/>
 users to customize their login interface with images or videos.  
@@ -65,21 +65,26 @@ It also supports automatic and manual switching between light and dark modes.
 - Customizable theme colors.
 - Support for using Bing images as login background.
 - Support for custom uploading of images or videos as login background.
-- Automatically switch between light and dark modes with the system, and can also be set to a fixed mode.
+- Automatically switch between light 和 dark modes with the system, 和 can also be set to a fixed mode.
 - Settings plugin with extensions [luci-app-argon-config][config-link]
 
 ## Notice
 - Chrome & Edge browser is highly recommended. There are some new css3 features used in this theme, currently only Chrome & Edge has the best compatibility.
 - FireFox does not enable the backdrop-filter by default, [see here](https://developer.mozilla.org/zh-CN/docs/Web/CSS/backdrop-filter) for the opening method.
+- __LEDE has upgraded LuCI to 23.05 since 10/17/2024. The 18.06 branch of this repository is no longer compatible with it. If you still need to compile or install the theme for the 18.06 branch, please modify the [feeds.conf.default](https://github.com/coolsnowwolf/lede/blob/master/feeds.conf.default) file in the LEDE before compiling the firmware. Revert it back to the previous 18.06 LuCI.__
 
 ## Getting started
 
-### Build for Lean's LEDE project
+### Build for Lean's LEDE ( LuCI 18.06 )
 
 ```bash
 cd lede
+sed -i '/^#src-git luci https:\/\/github.com\/coolsnowwolf\/luci$/s/^#//' feeds.conf.default && sed -i '/^src-git luci https:\/\/github.com\/coolsnowwolf\/luci\.git;openwrt-23\.05$/s/^/#/' feeds.conf.default
+./scripts/feeds clean
+./scripts/feeds update -a
 rm -rf feeds/luci/themes/luci-theme-argon
 git clone -b 18.06 https://github.com/jerrykuku/luci-theme-argon.git package/downloads/luci-theme-argon
+./scripts/feeds install -a
 make menuconfig #choose LuCI->Themes->luci-theme-argon
 make -j1 V=s
 ```
@@ -87,14 +92,14 @@ make -j1 V=s
 ### Install for LuCI 18.06 ( Lean's LEDE )
 
 ```bash
-wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.3/luci-theme-argon_1.8.3-20230710_all.ipk
+wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.4/luci-theme-argon_1.8.4-20241221_all.ipk
 opkg install luci-theme-argon*.ipk
 ```
 
-### Install luci-app-argon-config
+### Install the settings plugin with extensions - luci-app-argon-config
 
 ```bash
-wget --no-check-certificate https://github.com/jerrykuku/luci-app-argon-config/releases/download/v0.9/luci-app-argon-config_0.9_all.ipk
+wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.3/luci-app-argon-config_0.9-20220424_all.ipk
 opkg install luci-app-argon-config*.ipk
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It also supports automatic and manual switching between light and dark modes.
 
 [![license][license-badge]][license]
 [![prs][prs-badge]][prs]
-[![议题][issues-badge]][issues]
+[![issues][issues-badge]][issues]
 [![release][release-badge]][release]
 [![download][download-badge]][download]
 [![contact][contact-badge]][contact]

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -15,7 +15,7 @@
 [issues]: https://github.com/jerrykuku/luci-theme-argon/issues/new
 [issues-badge]: https://img.shields.io/badge/Issues-welcome-brightgreen.svg?style=flat-square
 [release]: https://github.com/jerrykuku/luci-theme-argon/releases
-[release-badge]: https://img.shields.io/badge/release-v1.8.3-blue.svg?
+[release-badge]: https://img.shields.io/badge/release-v1.8.4-blue.svg?
 [download]: https://github.com/jerrykuku/luci-theme-argon/releases
 [download-badge]: https://img.shields.io/github/downloads/jerrykuku/luci-theme-argon/total?style=flat-square
 [contact]: https://t.me/jerryk6
@@ -33,7 +33,7 @@
 <img src="https://raw.githubusercontent.com/jerrykuku/staff/master/argon_title4.svg">
 
 # 一个全新的 OpenWrt 主题
-### • 该分支只适配 [Lean's LEDE][lede] / [OpenWrt LuCI 18.06][official-luci-18.06] •
+### • 该分支只适配 [Lean's LEDE ( LuCI 18.06 )][lede] / [OpenWrt LuCI 18.06][official-luci-18.06] •
   
 Argon 是**一款干净整洁的 OpenWrt LuCI 主题**，  
 允许用户使用图片或视频自定义其登录界面。  
@@ -72,15 +72,20 @@ Argon 是**一款干净整洁的 OpenWrt LuCI 主题**，
 
 - 强烈建议使用 Chrome 和 Edge 浏览器。该主题中使用了一些新的 css3 功能，目前只有 Chrome 和 Edge 浏览器有最好的兼容性。
 - FireFox 默认不启用 backdrop-filter，[见这里](https://developer.mozilla.org/zh-CN/docs/Web/CSS/backdrop-filter)的打开方法。
+- __LEDE 自 2024-10-17，已将LuCI升级为23.05，本项目18.06分支的主题已不再兼容；如果你还需要继续编译或安装18.06分支的主题，请在编译LEDE固件前修改LEDE源码中的[feeds.conf.default](https://github.com/coolsnowwolf/lede/blob/master/feeds.conf.default)，将其更改回以前的18.06 LuCI，详见:[#428 (comment)](https://github.com/jerrykuku/luci-theme-argon/issues/428#issuecomment-2425167489)__
 
 ## 快速开始
 
-### 使用 Lean's LEDE 构建
+### 使用 Lean's LEDE ( LuCI 18.06 ) 构建
 
 ```bash
 cd lede
+sed -i '/^#src-git luci https:\/\/github.com\/coolsnowwolf\/luci$/s/^#//' feeds.conf.default && sed -i '/^src-git luci https:\/\/github.com\/coolsnowwolf\/luci\.git;openwrt-23\.05$/s/^/#/' feeds.conf.default
+./scripts/feeds clean
+./scripts/feeds update -a
 rm -rf feeds/luci/themes/luci-theme-argon
 git clone -b 18.06 https://github.com/jerrykuku/luci-theme-argon.git package/downloads/luci-theme-argon
+./scripts/feeds install -a
 make menuconfig #选择 LuCI->Themes->luci-theme-argon
 make -j1 V=s
 ```
@@ -88,15 +93,15 @@ make -j1 V=s
 ### 在 18.06 的 LuCI 上安装 ( Lean's LEDE )
 
 ```bash
-wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.3/luci-theme-argon_1.8.3-20230710_all.ipk
+wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.4/luci-theme-argon_1.8.4-20241221_all.ipk
 opkg install luci-theme-argon*.ipk
 ```
 
-### 安装 luci-app-argon-config
+### 安装扩展功能的设置插件 - luci-app-argon-config  
 
 ```bash
-wget --no-check-certificate https://github.com/jerrykuku/luci-app-argon-config/releases/download/v0.9/luci-app-argon-config_0.9_all.ipk
-wget --no-check-certificate https://github.com/jerrykuku/luci-app-argon-config/releases/download/v0.9/luci-i18n-argon-config-zh-cn_git-22.114.24542-d1474ba_all.ipk
+wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.3/luci-app-argon-config_0.9-20220424_all.ipk
+wget --no-check-certificate https://github.com/jerrykuku/luci-theme-argon/releases/download/v1.8.3/luci-i18n-argon-config-zh-cn_0.9-20220424_all.ipk
 opkg install luci-app-argon-config*.ipk
 opkg install luci-i18n-argon-config*.ipk
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -41,7 +41,7 @@ Argon 是**一款干净整洁的 OpenWrt LuCI 主题**，
 
 [![license][license-badge]][license]
 [![prs][prs-badge]][prs]
-[![议题][issues-badge]][issues]
+[![issues][issues-badge]][issues]
 [![release][release-badge]][release]
 [![download][download-badge]][download]
 [![contact][contact-badge]][contact]

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -1252,7 +1252,6 @@ ul li .cbi-input-checkbox {
 }
 .cbi-section-create {
   margin: 0;
-  padding-left: 0.5rem;
   align-items: center;
 }
 .cbi-section-create > * {
@@ -1626,20 +1625,25 @@ td > table > tbody > tr > td,
   top: 0;
   display: none;
 }
-#cbi-firewall-redirect table *,
-#cbi-network-switch_vlan table *,
-#cbi-firewall-zone table * {
+#cbi-firewall-redirect table *:not([type="button"]),
+#cbi-firewall-rule table *:not([type="button"]),
+#cbi-network-switch_vlan table *:not([type="button"]),
+#cbi-firewall-zone table *:not([type="button"]) {
   font-size: small;
 }
 #cbi-firewall-redirect table input[type="text"],
 #cbi-network-switch_vlan table input[type="text"],
-#cbi-firewall-zone table input[type="text"] {
-  width: 5rem;
+#cbi-firewall-zone table input[type="text"],
+#cbi-firewall-rule table input[type="text"] {
+  width: inherit !important;
+  text-align: center;
 }
 #cbi-firewall-redirect table select,
 #cbi-network-switch_vlan table select,
 #cbi-firewall-zone table select {
   min-width: 3.5rem;
+  text-align: center;
+  text-align-last: center;
 }
 #cbi-network-switch_vlan .th,
 #cbi-network-switch_vlan .td {
@@ -2133,7 +2137,7 @@ table > thead > tr > th {
   padding-left: 1.5rem;
   color: #8898aa;
   background-color: #f6f9fc;
-  font-size: 0.65rem;
+  font-size: 0.75rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   letter-spacing: 1px;
@@ -2756,7 +2760,7 @@ td > .ifacebadge,
   min-width: 7rem;
 }
 .cbi-section-create > .cbi-button-add {
-  margin: 0.75rem 0.75rem 0.75rem 0.25rem;
+  margin: 0.75rem 0.75rem 0.75rem 0.75rem;
 }
 .cbi-section-remove {
   padding: 0.5rem;
@@ -3221,8 +3225,7 @@ div.commandbox {
   }
   select,
   input {
-    width: 100% !important;
-    min-width: auto;
+    min-width: max-content;
     margin: 0.25rem 0;
   }
   input {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -3029,19 +3029,19 @@ div.commandbox {
 
 /* luci-app-ttyd */
 .TTYD.node-system-terminal .main {
-  height: 100%!important;
+  height: 100% !important;
 }
 .TTYD.node-system-terminal .main .main-right,
 .TTYD.node-system-terminal .main .main-right #maincontent,
 .TTYD.node-system-terminal .main .main-right #maincontent .container .cbi-map {
-  height: 100%!important;
-  display: flex!important;
-  flex-direction: column!important;
+  height: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
 }
 .TTYD.node-system-terminal .main .main-right #maincontent,
 .TTYD.node-system-terminal .main .main-right #maincontent .container,
 .TTYD.node-system-terminal .main .main-right #maincontent .container .cbi-map #terminal {
-  flex: 1!important;
+  flex: 1 !important;
 }
 
 @media screen and (max-width: 1600px) {

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -3044,6 +3044,15 @@ div.commandbox {
   flex: 1 !important;
 }
 
+/* luci-app-nlbwmon */
+[class*="node-nlbw-usage"] #intervalSelect {
+  height: unset !important;
+}
+[class*="node-nlbw-usage"] #resetDatabase {
+  bottom: 20px !important;
+  right: 4px !important;
+}
+
 @media screen and (max-width: 1600px) {
   .main .main-left {
     width: calc(0% + 13rem);

--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -2203,8 +2203,8 @@ div::-webkit-scrollbar {
 .tabs li[class~="active"],
 .tabs li:hover {
   cursor: pointer;
-  border-bottom: 0.18751rem solid #5e72e4;
-  border-bottom: 0.18751rem solid var(--primary);
+  border-bottom: 0.18751rem solid #5e72e4 !important;
+  border-bottom: 0.18751rem solid var(--primary) !important;
   color: #5e72e4;
   color: var(--primary);
   background-color: var(--light-subtabs-background);
@@ -2226,10 +2226,6 @@ div::-webkit-scrollbar {
   text-decoration: none;
   color: #404040;
   padding: 0.5rem 0.8rem;
-}
-.tabs li:hover {
-  border-bottom: 0.18751rem solid #5e72e4;
-  border-bottom: 0.18751rem solid var(--primary);
 }
 .cbi-tabmenu {
   color: white;
@@ -2261,7 +2257,7 @@ div::-webkit-scrollbar {
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
   padding: 0.5rem 0rem;
-  border-bottom: 0.18751rem solid rgba(0, 0, 0, 0);
+  border-bottom: 0.18751rem solid rgba(0, 0, 0, 0) !important;
 }
 .cbi-tabmenu li a {
   text-decoration: none;
@@ -2270,8 +2266,8 @@ div::-webkit-scrollbar {
 }
 .cbi-tabmenu li:hover {
   cursor: pointer;
-  border-bottom: 0.18751rem solid #5e72e4;
-  border-bottom: 0.18751rem solid var(--primary);
+  border-bottom: 0.18751rem solid #5e72e4 !important;
+  border-bottom: 0.18751rem solid var(--primary) !important;
   color: #5e72e4;
   color: var(--primary);
   background-color: var(--light-subtabs-background);
@@ -2281,8 +2277,8 @@ div::-webkit-scrollbar {
   color: #525f7f;
 }
 .cbi-tabmenu li[class~="cbi-tab"] {
-  border-bottom: 0.18751rem solid #5e72e4;
-  border-bottom: 0.18751rem solid var(--primary);
+  border-bottom: 0.18751rem solid #5e72e4 !important;
+  border-bottom: 0.18751rem solid var(--primary) !important;
   color: var(--primary);
   background-color: var(--light-subtabs-background);
   margin-bottom: 0;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -2663,8 +2663,8 @@ td>table>tbody>tr>td {
     li[class~="active"],
     li:hover {
         cursor: pointer;
-        border-bottom: 0.18751rem solid #5e72e4;
-        border-bottom: 0.18751rem solid var(--primary);
+        border-bottom: 0.18751rem solid #5e72e4 !important;
+        border-bottom: 0.18751rem solid var(--primary) !important;
         color: #5e72e4;
         color: var(--primary);
         background-color: var(--light-subtabs-background);
@@ -2687,11 +2687,6 @@ td>table>tbody>tr>td {
             text-decoration: none;
             color: #404040;
             padding: 0.5rem 0.8rem;
-        }
-
-        &:hover {
-            border-bottom: 0.18751rem solid #5e72e4;
-            border-bottom: 0.18751rem solid var(--primary);
         }
     }
 }
@@ -2739,7 +2734,7 @@ div::-webkit-scrollbar {
         border-top-left-radius: 0.25rem;
         border-top-right-radius: 0.25rem;
         padding: 0.5rem 0rem;
-        border-bottom: 0.18751rem solid rgba(0, 0, 0, 0);
+        border-bottom: 0.18751rem solid rgba(0, 0, 0, 0) !important;
 
         a {
             text-decoration: none;
@@ -2749,8 +2744,8 @@ div::-webkit-scrollbar {
 
         &:hover {
             cursor: pointer;
-            border-bottom: 0.18751rem solid #5e72e4;
-            border-bottom: 0.18751rem solid var(--primary);
+            border-bottom: 0.18751rem solid #5e72e4 !important;
+            border-bottom: 0.18751rem solid var(--primary) !important;
             color: #5e72e4;
             color: var(--primary);
             background-color: var(--light-subtabs-background);
@@ -2763,8 +2758,8 @@ div::-webkit-scrollbar {
     }
 
     li[class~="cbi-tab"] {
-        border-bottom: 0.18751rem solid #5e72e4;
-        border-bottom: 0.18751rem solid var(--primary);
+        border-bottom: 0.18751rem solid #5e72e4 !important;
+        border-bottom: 0.18751rem solid var(--primary) !important;
         color: var(--primary);
         background-color: var(--light-subtabs-background);
         margin-bottom: 0;

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3723,6 +3723,15 @@ div.commandbox {
     flex: 1 !important;
 }
 
+/* luci-app-nlbwmon */
+[class*="node-nlbw-usage"] #intervalSelect {
+    height: unset !important;
+}
+[class*="node-nlbw-usage"] #resetDatabase {
+    bottom: 20px !important;
+    right: 4px !important;
+}
+
 @media screen and (max-width: 1600px) {
 
     .main {

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -1490,7 +1490,6 @@ ul li .cbi-input-checkbox {
 
 .cbi-section-create {
     margin: 0;
-    padding-left: 0.5rem;
     align-items: center;
 
 }
@@ -1951,22 +1950,27 @@ td>table>tbody>tr>td,
 }
 
 
-#cbi-firewall-redirect table *,
-#cbi-network-switch_vlan table *,
-#cbi-firewall-zone table * {
+#cbi-firewall-redirect table *:not([type="button"]),
+#cbi-firewall-rule table *:not([type="button"]),
+#cbi-network-switch_vlan table *:not([type="button"]),
+#cbi-firewall-zone table *:not([type="button"]) {
     font-size: small;
 }
 
 #cbi-firewall-redirect table input[type="text"],
 #cbi-network-switch_vlan table input[type="text"],
-#cbi-firewall-zone table input[type="text"] {
-    width: 5rem;
+#cbi-firewall-zone table input[type="text"],
+#cbi-firewall-rule table input[type="text"] {
+    width: inherit !important;
+    text-align: center;
 }
 
 #cbi-firewall-redirect table select,
 #cbi-network-switch_vlan table select,
 #cbi-firewall-zone table select {
     min-width: 3.5rem;
+    text-align: center;
+    text-align-last: center;
 }
 
 #cbi-network-switch_vlan .th,
@@ -2568,12 +2572,11 @@ table>thead>tr>td {
 table>tbody>tr>th,
 table>tfoot>tr>th,
 table>thead>tr>th {
-
     padding-right: 1.5rem;
     padding-left: 1.5rem;
     color: #8898aa;
     background-color: #f6f9fc;
-    font-size: .65rem;
+    font-size: .75rem;
     padding-top: .75rem;
     padding-bottom: .75rem;
     letter-spacing: 1px;
@@ -3360,7 +3363,7 @@ td>.ifacebadge,
 }
 
 .cbi-section-create>.cbi-button-add {
-    margin: 0.75rem 0.75rem 0.75rem 0.25rem;
+    margin: 0.75rem 0.75rem 0.75rem 0.75rem;
 }
 
 .cbi-section-remove {
@@ -3979,8 +3982,7 @@ div.commandbox {
 
     select,
     input {
-        width: 100% !important;
-        min-width: auto;
+        min-width: max-content;
         margin: 0.25rem 0;
     }
 

--- a/htdocs/luci-static/argon/less/cascade.less
+++ b/htdocs/luci-static/argon/less/cascade.less
@@ -3708,19 +3708,19 @@ div.commandbox {
 
 /* luci-app-ttyd */
 .TTYD.node-system-terminal .main {
-    height: 100%!important;
+    height: 100% !important;
 }
 .TTYD.node-system-terminal .main .main-right,
 .TTYD.node-system-terminal .main .main-right #maincontent,
 .TTYD.node-system-terminal .main .main-right #maincontent .container .cbi-map {
-    height: 100%!important;
-    display: flex!important;
-    flex-direction: column!important;
+    height: 100% !important;
+    display: flex !important;
+    flex-direction: column !important;
 }
 .TTYD.node-system-terminal .main .main-right #maincontent,
 .TTYD.node-system-terminal .main .main-right #maincontent .container,
 .TTYD.node-system-terminal .main .main-right #maincontent .container .cbi-map #terminal {
-    flex: 1!important;
+    flex: 1 !important;
 }
 
 @media screen and (max-width: 1600px) {


### PR DESCRIPTION
_**EOL更新**_
由于LEDE已将LuCI版本升级为23.05, 故本主题18.06分支, 无意外将是最后一次更新.
本次更新主要完善主题细节.

- 适配/改进: _**TTYD终端 [luci-app-ttyd]**_  感谢@yhl452493373 

- 改进: 为 _**登录页面[sysauth]**_ 中 _**主机名[brand-text]**_ 增加1px _**字间距[letter-spacing]**_,
并将文本的 _**底部内间距[padding-bottom]**_ 增加0.1rem, 以避免小写字母y和g显示不全

- 修复 移动端页面 下, 在 _**概况[overview]**_ 中 _**[IPv4 WAN 状态]**_ 和 _**[IPv6 WAN 状态]**_ 显示布局未对齐

- 改进: _**防火墙[firewall]**_ 显示布局

- 修复 在新版Edge浏览器下, 最后一个 _**子选项卡[Sub-tabs]**_ 显示异常

- 适配/改进: _**实时流量监测[luci-app-nlbwmon]**_ 控件布局