### PR TITLE
fix uci config read fail on openwrt 24.10

### DIFF
--- a/root/usr/share/rpcd/acl.d/luci-theme-argon.json
+++ b/root/usr/share/rpcd/acl.d/luci-theme-argon.json
@@ -1,0 +1,8 @@
+{
+    "luci-theme-argon": {
+        "description": "Grant UCI access for luci-theme-argon",
+        "read": {
+            "uci": [ "argon" ]
+        }
+    }
+}


### PR DESCRIPTION
If luci-app-argon-config is not installed, the argon uci config will fail to read, resulting in empty color variables.

openwrt 24.10下，如果未安装 luci-app-argon-config，但是又导入了`/etc/config/argon`（例如从备份文件恢复），uci读取失败，导致颜色变量为空，页面很多元素变成白色。

看起来lua中读写uci也按登录用户鉴权了，目前不知道这是luci的bug还是新的安全机制。

反正我们加上这个acl声明文件，确保万无一失。
