### PR TITLE
Update README: Correct wget usage for luci-app-argon-config installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ opkg install luci-theme-argon*.ipk
 ### Install luci-app-argon-config
 
 ```bash
-wget --no-check-certificate https://github.com/jerrykuku/luci-app-argon-config/releases/download/v0.9/luci-app-argon-config_0.9_all.ipk
+wget --no-check-certificate -O luci-app-argon-config_0.9_all.ipk https://github.com/jerrykuku/luci-app-argon-config/releases/download/v0.9/luci-app-argon-config_0.9_all.ipk
 opkg install luci-app-argon-config*.ipk
 ```
 


### PR DESCRIPTION
Updated the installation instructions for luci-app-argon-config to prevent file renaming issues during download.  Replaced the wget command with one that specifies the output filename explicitly using the `-O` option.  This ensures a consistent filename for the .ipk package, improving clarity and reducing installation errors.