### PR TITLE
Update cascade.less: brand text breaks on login page and all textes on Sidenav break when too long now

### DIFF
--- a/less/cascade.less
+++ b/less/cascade.less
@@ -542,7 +542,8 @@ h5 {
           font-size: 1.25rem;
           font-weight: 700;
           font-family: "TypoGraphica";
-
+          margin-right: 45px;
+          word-break: break-word;
         }
 
         &:hover {
@@ -747,7 +748,7 @@ small {
   box-shadow: rgba(0, 0, 0, 0.75) 0px 0px 15px -5px;
   overflow-x: auto;
   z-index: 100;
-
+  word-break: break-word;
 
   .sidenav-header {
     padding: 1.5rem .5rem;


### PR DESCRIPTION
Someone requested a change for too long hostnames/brand textes not breaking correctly.

This would be the easiest change. However the text which appears in the mobile version without the sidenav still does not break. I believe it should be deleted anyway for clearer design. Or make the text smaller in mobile view and put a wrapper around it which truncates the word with "..." at the end after 16 chars.