### PR TITLE
fix ddns log can not scroll

### DIFF
--- a/less/cascade.less
+++ b/less/cascade.less
@@ -3041,6 +3041,10 @@ td > .ifacebadge,
   outline: 0;
 }
 
+#cbi-ddns #syslog {
+  overflow: auto;
+}
+
 /* config changes */
 .uci-change-list {
   font-family: inherit;


### PR DESCRIPTION
修复 DDNS 服务查看日志时无法滚动的问题。

DDNS 日志的textarea控件也用了`id="syslog"`。

PR #579 也是修复此问题
