### PR TITLE
Dynlist indicate drop target

### DIFF
--- a/less/cascade.less
+++ b/less/cascade.less
@@ -2361,6 +2361,7 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
       transition: box-shadow 0.15s ease;
       overflow: hidden;
       text-overflow: ellipsis;
+      user-select: text;
 
       white-space: nowrap;
       word-break: break-word;


### PR DESCRIPTION
动态列表完善。

动态列表现在实际上支持拖拽调整顺序，例如“系统”-“系统”-“时间同步”中的“候选 NTP 服务器”列表，argon虽然没任何指示支持拖拽，但是按住X号按钮是可以拖拽调整顺序的，因为这个功能是luci的js实现的，跟主题没多大关系。

这个PR就是增加拖拽目标的指示，在目标上方显示红色横线，表示释放以后将插入的位置。

另外，动态列表应该要允许用户选择文本，因为动态列表的项目添加以后是无法再编辑的，要修改的话只能删掉以后重新添加，用户可能只是想改一两个字符，全部重新输入不合理，所以此PR允许用户选择/复制旧值，以便重新添加。