### PR TITLE
header.htm: fix luci.js double included

### DIFF
--- a/luasrc/view/themes/argon/header.htm
+++ b/luasrc/view/themes/argon/header.htm
@@ -128,7 +128,6 @@
 	<% end -%>
 	<script src="<%=url('admin/translations', luci.i18n.context.lang)%>?v=<%=ver.luciversion%>"></script>
 	<script src="<%=resource%>/cbi.js?v=<%=ver.luciversion%>"></script>
-	<script src="<%=resource%>/luci.js?v=<%=ver.luciversion%>"></script>
 </head>
 
 <body


### PR DESCRIPTION
luci.js will be included in luci-base's header.htm or header.ut:
https://github.com/openwrt/luci/blob/openwrt-22.03/modules/luci-base/luasrc/view/header.htm
https://github.com/openwrt/luci/blob/openwrt-24.10/modules/luci-base/ucode/template/header.ut

header.ut 这里还使用了新的版本号规则，所以主题这边还是别加载luci.js了。