### PR TITLE
Wallhaven.cc loading fix

### DIFF
--- a/root/usr/libexec/rpcd/luci.argon_wallpaper
+++ b/root/usr/libexec/rpcd/luci.argon_wallpaper
@@ -74,6 +74,16 @@ try_update() {
 	if flock -n 200 >"/dev/null" 2>&1; then
 		local picurl="$(fetch_pic_url)"
 		if [ -n "$picurl" ]; then
+
+			# below is quirk fix for all browsers
+			# for some weird reason on first load, wallhaven images needs to be
+			# download or browsed first before it can be shown as a background image
+			# if not, browser only displays a blank image
+			# NOTE: only happens to Wallhaven.cc source images
+			if [[ "$WEB_PIC_SRC" == wallhave* ]] ; then
+				wget -T3 -qO- "${picurl}" > /dev/null
+			fi
+
 			echo "$picurl" | tee "$CACHE"
 		else
 			if [ -s "$CACHE" ]; then


### PR DESCRIPTION
- specific to wallhaven.cc
- fixes initial loading as it shows (for some weird reason) as blank image
- only happens with wallhaven.cc sources/images

NOTE: I made a PR for this last year and was merged.  I think it was removed when curl was removed and changed to wget.