### PR TITLE
Update LUCI_DEPENDS to use wget-any

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
-LUCI_DEPENDS:=+wget +jsonfilter
+LUCI_DEPENDS:=+wget-any +jsonfilter
 PKG_VERSION:=2.4.3
 PKG_RELEASE:=20250722
 


### PR DESCRIPTION
Openwrt中轻量级wget实现uclient-fetch提供@wget-any虚拟包。
经测试，在系统中可以以别名wget被调用的uclient-fetch，已经覆盖本主题所需功能。
无需依赖wget-ssl等更”重“的包，对小闪存路由器更友好~