### PR TITLE
Revert "Update LUCI_DEPENDS to use wget-any"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
-LUCI_DEPENDS:=+wget-any +jsonfilter
+LUCI_DEPENDS:=+wget +jsonfilter
 PKG_VERSION:=2.4.3
 PKG_RELEASE:=20250722
 


### PR DESCRIPTION
Reverts jerrykuku/luci-theme-argon#671

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts a package dependency in the `Makefile`, with limited surface area. Risk is mainly build/install compatibility if targets relied on `wget-any` behavior.
> 
> **Overview**
> Reverts the Argon theme package dependency change by replacing `LUCI_DEPENDS:=+wget-any` with `LUCI_DEPENDS:=+wget` in the `Makefile`, keeping `+jsonfilter` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e59a7efa8fe7dd988b6e7127bf160f5021096e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->