### PR TITLE
fix(css): remove transform on tooltip

### DIFF
--- a/less/cascade.less
+++ b/less/cascade.less
@@ -2251,7 +2251,6 @@ span[data-tooltip] .label {
   padding: 0.5rem;
   opacity: 0;
   transition: opacity .25s ease-in;
-  transform: translate(-50%, 10%);
 }
 
 .cbi-tooltip-container:hover .cbi-tooltip:not(:empty) {


### PR DESCRIPTION

<img width="864" height="380" alt="image" src="https://github.com/user-attachments/assets/c5c25e1e-e7f5-488c-824c-0495e7912d7b" />

`transform` had the effect of cutting the tooltip against the menu section.
Therefore, it is removed.