### PR TITLE
修复输入框显示不全

### DIFF
--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -55,6 +55,7 @@
   --font-family-sans-serif: "Google Sans", "Microsoft Yahei", "WenQuanYi Micro Hei", "sans-serif", "Helvetica Neue", "Helvetica", "Hiragino Sans GB";
   --dropdown-arrow-icon: url("data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik01LjI5MyA5LjI5M2ExIDEgMCAwIDEgMS40MTQgMEwxMiAxNC41ODZsNS4yOTMtNS4yOTNhMSAxIDAgMSAxIDEuNDE0IDEuNDE0bC02IDZhMSAxIDAgMCAxLTEuNDE0IDBsLTYtNmExIDEgMCAwIDEgMC0xLjQxNCIvPjwvc3ZnPg==");
 }
+
 /*
  *  Include base and custom css
  */
@@ -65,6 +66,7 @@
   font-style: normal;
   font-display: swap;
 }
+
 /*  Logo Font */
 @font-face {
   font-family: 'TypoGraphica';
@@ -73,6 +75,7 @@
   font-style: normal;
   font-display: swap;
 }
+
 /* Icon Font */
 @font-face {
   font-family: 'argon';
@@ -81,15 +84,18 @@
   font-style: normal;
   font-display: swap;
 }
+
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
+
 html {
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
 }
+
 html,
 body {
   margin: 0;
@@ -97,15 +103,18 @@ body {
   height: 100%;
   font-family: var(--font-family-sans-serif);
 }
+
 body {
   background-color: var(--background-color);
   color: var(--gray-dark);
   -webkit-tap-highlight-color: transparent;
   font-size: 0.875rem;
 }
+
 main {
   display: block;
 }
+
 .h1,
 .h2,
 .h3,
@@ -123,12 +132,14 @@ h6 {
   line-height: 1.1 !important;
   color: inherit;
 }
+
 h1 {
   font-size: 2rem;
   margin: 0.67em 0;
   padding-bottom: 0.5rem;
   border-bottom: thin solid var(--lighter);
 }
+
 h2 {
   padding: 1rem 1.25rem;
   font-size: 1.25rem;
@@ -138,6 +149,7 @@ h2 {
   background: var(--white);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.03);
 }
+
 h3 {
   margin: 0;
   padding: 0.8755rem 1.25rem;
@@ -150,6 +162,7 @@ h3 {
   display: block;
   width: 100%;
 }
+
 h4 {
   margin: 0;
   padding: 0.75rem 1.25rem;
@@ -157,32 +170,39 @@ h4 {
   font-weight: bold;
   color: var(--gray-dark-400);
 }
+
 h4 em {
   padding: 0 0.5rem;
 }
+
 h5 {
   margin: 2rem 0 0 0;
   padding-bottom: 0.5rem;
   font-size: 1rem;
 }
+
 a {
   background-color: transparent;
 }
+
 abbr {
   cursor: help;
   text-decoration: underline;
   color: var(--primary);
 }
+
 abbr[title] {
   border-bottom: none;
   text-decoration: underline;
   -webkit-text-decoration: underline dotted;
   text-decoration: underline dotted;
 }
+
 b,
 strong {
   font-weight: bolder;
 }
+
 code,
 kbd,
 samp {
@@ -193,11 +213,13 @@ samp {
   border-radius: 0.5rem;
   background: var(--lighter);
 }
+
 small {
   font-size: 90%;
   line-height: 1.42857143;
   white-space: normal;
 }
+
 sub,
 sup {
   font-size: 75%;
@@ -205,12 +227,15 @@ sup {
   position: relative;
   vertical-align: baseline;
 }
+
 sub {
   bottom: -0.25em;
 }
+
 sup {
   top: -0.5em;
 }
+
 hr {
   box-sizing: content-box;
   height: 0;
@@ -219,14 +244,17 @@ hr {
   opacity: 0.1;
   border-color: var(--lighter);
 }
+
 pre {
   font-family: monospace, monospace;
   font-size: 1em;
   overflow: auto;
 }
+
 img {
   border-style: none;
 }
+
 button,
 input,
 optgroup,
@@ -237,14 +265,17 @@ textarea {
   line-height: 1.15;
   margin: 0;
 }
+
 button,
 input {
   overflow: visible;
 }
+
 button,
 select {
   text-transform: none;
 }
+
 [type=button],
 [type=reset],
 [type=submit],
@@ -252,6 +283,7 @@ button {
   -webkit-appearance: button;
   appearance: button;
 }
+
 [type=button]::-moz-focus-inner,
 [type=reset]::-moz-focus-inner,
 [type=submit]::-moz-focus-inner,
@@ -259,35 +291,42 @@ button::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
+
 [type=button]:-moz-focusring,
 [type=reset]:-moz-focusring,
 [type=submit]:-moz-focusring,
 button:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
+
 [type=checkbox],
 [type=radio] {
   box-sizing: border-box;
   padding: 0;
 }
+
 [type=number]::-webkit-inner-spin-button,
 [type=number]::-webkit-outer-spin-button {
   height: auto;
 }
+
 [type=search] {
   -webkit-appearance: textfield;
   appearance: textfield;
   outline-offset: -2px;
 }
+
 [type=search]::-webkit-search-decoration {
   -webkit-appearance: none;
   appearance: none;
 }
+
 ::-webkit-file-upload-button {
   -webkit-appearance: button;
   appearance: button;
   font: inherit;
 }
+
 input[type="checkbox"] {
   appearance: none !important;
   -webkit-appearance: none !important;
@@ -298,6 +337,7 @@ input[type="checkbox"] {
   cursor: pointer;
   transition: all 0.2s;
 }
+
 input[type="checkbox"]:checked {
   border: 1px solid var(--primary);
   background-image: url('data:image/svg+xml,%3csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 8 8\'%3e%3cpath fill=\'%23fff\' d=\'M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z\'/%3e%3c/svg%3e') !important;
@@ -306,6 +346,7 @@ input[type="checkbox"]:checked {
   background-repeat: no-repeat;
   background-position: center;
 }
+
 select {
   padding: 0.36rem 0.8rem;
   color: var(--gray-dark);
@@ -313,17 +354,21 @@ select {
   background-color: var(--white);
   background-image: none;
 }
+
 textarea {
   padding: 0.25rem;
   overflow: auto;
 }
+
 textarea:focus-visible {
   outline: none;
   border: 1px solid var(--primary);
 }
+
 fieldset {
   padding: 0.35em 0.75em 0.625em;
 }
+
 legend {
   box-sizing: border-box;
   color: inherit;
@@ -332,55 +377,71 @@ legend {
   padding: 0;
   white-space: normal;
 }
+
 details {
   display: block;
 }
+
 summary {
   display: list-item;
 }
+
 template {
   display: none;
 }
+
 progress {
   vertical-align: baseline;
 }
+
 ul {
   line-height: normal;
 }
+
 li {
   list-style-type: none;
 }
+
 [disabled="disabled"] {
   pointer-events: none;
 }
+
 ::selection {
   background-color: var(--primary);
   color: var(--white);
 }
+
 ::placeholder {
   color: var(--lighter);
 }
+
 a:link,
 a:visited,
 a:active {
   color: var(--primary);
   text-decoration: none;
 }
+
 a:hover {
   text-decoration: underline;
 }
+
 .pull-right {
   float: right;
 }
+
 .pull-left {
   float: left;
 }
+
 .nowrap:not(.td) {
   white-space: nowrap;
 }
+
 div[style="width:100%;height:300px;border:1px solid #000;background:#fff"] {
   border: 0 !important;
 }
+
 /**
 Pure v3.0.0
 Copyright 2013 Yahoo!
@@ -397,10 +458,12 @@ Copyright (c) Nicolas Gallagher and Jonathan Neal
   flex-flow: row wrap;
   align-content: flex-start;
 }
+
 .pure-u {
   display: inline-block;
   vertical-align: top;
 }
+
 .pure-u-1,
 .pure-u-1-1,
 .pure-u-1-12,
@@ -453,154 +516,198 @@ Copyright (c) Nicolas Gallagher and Jonathan Neal
   vertical-align: top;
   text-rendering: auto;
 }
+
 .pure-u-1-24 {
   width: 4.1667%;
 }
+
 .pure-u-1-12,
 .pure-u-2-24 {
   width: 8.3333%;
 }
+
 .pure-u-1-8,
 .pure-u-3-24 {
   width: 12.5%;
 }
+
 .pure-u-1-6,
 .pure-u-4-24 {
   width: 16.6667%;
 }
+
 .pure-u-1-5 {
   width: 20%;
 }
+
 .pure-u-5-24 {
   width: 20.8333%;
 }
+
 .pure-u-1-4,
 .pure-u-6-24 {
   width: 25%;
 }
+
 .pure-u-7-24 {
   width: 29.1667%;
 }
+
 .pure-u-1-3,
 .pure-u-8-24 {
   width: 33.3333%;
 }
+
 .pure-u-3-8,
 .pure-u-9-24 {
   width: 37.5%;
 }
+
 .pure-u-2-5 {
   width: 40%;
 }
+
 .pure-u-10-24,
 .pure-u-5-12 {
   width: 41.6667%;
 }
+
 .pure-u-11-24 {
   width: 45.8333%;
 }
+
 .pure-u-1-2,
 .pure-u-12-24 {
   width: 50%;
 }
+
 .pure-u-13-24 {
   width: 54.1667%;
 }
+
 .pure-u-14-24,
 .pure-u-7-12 {
   width: 58.3333%;
 }
+
 .pure-u-3-5 {
   width: 60%;
 }
+
 .pure-u-15-24,
 .pure-u-5-8 {
   width: 62.5%;
 }
+
 .pure-u-16-24,
 .pure-u-2-3 {
   width: 66.6667%;
 }
+
 .pure-u-17-24 {
   width: 70.8333%;
 }
+
 .pure-u-18-24,
 .pure-u-3-4 {
   width: 75%;
 }
+
 .pure-u-19-24 {
   width: 79.1667%;
 }
+
 .pure-u-4-5 {
   width: 80%;
 }
+
 .pure-u-20-24,
 .pure-u-5-6 {
   width: 83.3333%;
 }
+
 .pure-u-21-24,
 .pure-u-7-8 {
   width: 87.5%;
 }
+
 .pure-u-11-12,
 .pure-u-22-24 {
   width: 91.6667%;
 }
+
 .pure-u-23-24 {
   width: 95.8333%;
 }
+
 .pure-u-1,
 .pure-u-1-1,
 .pure-u-24-24,
 .pure-u-5-5 {
   width: 100%;
 }
+
 .col-1 {
   flex: 1 1 30px !important;
 }
+
 .col-2 {
   flex: 2 2 60px !important;
 }
+
 .col-3 {
   flex: 3 3 90px !important;
 }
+
 .col-4 {
   flex: 4 4 120px !important;
 }
+
 .col-5 {
   flex: 5 5 150px !important;
 }
+
 .col-6 {
   flex: 6 6 180px !important;
 }
+
 .col-7 {
   flex: 7 7 210px !important;
 }
+
 .col-8 {
   flex: 8 8 240px !important;
 }
+
 .col-9 {
   flex: 9 9 270px !important;
 }
+
 .col-10 {
   flex: 10 10 300px !important;
 }
+
 .table {
   position: relative;
   display: table;
 }
+
 .tr {
   display: table-row;
 }
+
 .thead {
   display: table-header-group;
 }
+
 .tbody {
   display: table-row-group;
 }
+
 .tfoot {
   display: table-footer-group;
 }
+
 .td,
 .th {
   line-height: normal;
@@ -609,14 +716,17 @@ Copyright (c) Nicolas Gallagher and Jonathan Neal
   text-align: center;
   vertical-align: middle;
 }
+
 .th {
   font-weight: bold;
   white-space: nowrap;
 }
+
 .tr.placeholder {
   height: 4em;
 }
-.tr.placeholder > .td {
+
+.tr.placeholder>.td {
   line-height: 3;
   position: absolute;
   right: 0;
@@ -626,19 +736,23 @@ Copyright (c) Nicolas Gallagher and Jonathan Neal
   text-align: center !important;
   background: inherit;
 }
+
 .td[width="33%"] {
   padding: 1.1em 1.5rem;
 }
+
 .table[width="33%"],
 .th[width="33%"],
 .td[width="33%"] {
   width: 33%;
 }
+
 .table[width="100%"],
 .th[width="100%"],
 .td[width="100%"] {
   width: 100%;
 }
+
 .btn,
 button,
 select,
@@ -655,6 +769,7 @@ input,
   box-shadow: none;
   transition: box-shadow 0.15s ease;
 }
+
 select {
   padding-right: 1.5rem;
   background-image: url("data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSIjODg5OGFhIiBkPSJNNS4yOTMgOS4yOTNhMSAxIDAgMCAxIDEuNDE0IDBMMTIgMTQuNTg2bDUuMjkzLTUuMjkzYTEgMSAwIDEgMSAxLjQxNCAxLjQxNGwtNiA2YTEgMSAwIDAgMS0xLjQxNCAwbC02LTZhMSAxIDAgMCAxIDAtMS40MTQiLz48L3N2Zz4=");
@@ -663,21 +778,25 @@ select {
   background-repeat: no-repeat;
   appearance: none;
 }
+
 select:not([multiple="multiple"]):focus,
 input:not(.cbi-button):focus,
 .cbi-dropdown:focus {
   border-color: var(--primary);
   box-shadow: 0 3px 9px rgba(50, 50, 9, 0), 3px 4px 8px rgba(94, 114, 228, 0.1);
 }
+
 .cbi-dropdown,
 select[multiple="multiple"] {
   height: auto;
 }
+
 .login-page {
   display: flex;
   height: 100%;
   flex-direction: column;
 }
+
 .login-page .video {
   position: absolute;
   top: 0;
@@ -690,10 +809,12 @@ select[multiple="multiple"] {
   background-color: var(--darker);
   overflow: hidden;
 }
+
 .login-page .video video {
   width: 100%;
   height: auto;
 }
+
 .login-page .volume-control {
   position: fixed;
   top: 1rem;
@@ -704,9 +825,11 @@ select[multiple="multiple"] {
   cursor: pointer;
   background: url(../img/volume_high.svg) no-repeat center / contain;
 }
+
 .login-page .volume-control.mute {
   background-image: url(../img/volume_off.svg);
 }
+
 .login-page .main-bg {
   position: absolute;
   top: 0;
@@ -716,6 +839,7 @@ select[multiple="multiple"] {
   background: url(../img/blank.png) no-repeat center / cover;
   transition: all 0.5s ease;
 }
+
 .login-page .login-container {
   z-index: 10;
   margin-left: 5%;
@@ -728,6 +852,7 @@ select[multiple="multiple"] {
   background-color: rgba(244, 245, 247, var(--blur-opacity));
   box-shadow: rgba(0, 0, 0, 0.75) 0 0 35px -5px;
 }
+
 .login-page .login-container .login-form {
   position: relative;
   top: 0;
@@ -741,6 +866,7 @@ select[multiple="multiple"] {
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
+
 .login-page .login-container .login-form .brand {
   display: flex;
   align-items: center;
@@ -749,11 +875,13 @@ select[multiple="multiple"] {
   color: var(--default);
   text-decoration: none;
 }
+
 .login-page .login-container .login-form .brand .icon {
   width: 50px;
   height: auto;
   margin-right: 25px;
 }
+
 .login-page .login-container .login-form .brand .brand-text {
   margin-right: 45px;
   font-size: 1.25rem;
@@ -761,23 +889,28 @@ select[multiple="multiple"] {
   font-family: "TypoGraphica";
   word-break: break-word;
 }
+
 .login-page .login-container .login-form .brand:hover {
   text-decoration: none;
 }
+
 .login-page .login-container .login-form .form-login {
   width: 100%;
   padding: 20px 50px;
   box-sizing: border-box;
 }
+
 .login-page .login-container .login-form .form-login .errorbox {
   padding-bottom: 2rem;
   text-align: center;
   color: var(--warning);
 }
+
 .login-page .login-container .login-form .form-login .input-group {
   position: relative;
   margin-bottom: 1.25rem;
 }
+
 .login-page .login-container .login-form .form-login .input-group::before {
   font-family: 'argon' !important;
   font-style: normal;
@@ -794,6 +927,7 @@ select[multiple="multiple"] {
   font-size: 1.5rem;
   color: var(--default);
 }
+
 .login-page .login-container .login-form .form-login .input-group .border {
   position: absolute;
   bottom: 0;
@@ -803,6 +937,7 @@ select[multiple="multiple"] {
   transform: scaleX(0);
   transition: transform 0.3s ease;
 }
+
 .login-page .login-container .login-form .form-login .input-group input {
   display: block;
   width: 100%;
@@ -821,19 +956,24 @@ select[multiple="multiple"] {
   box-shadow: 0 3px 2px rgba(233, 236, 239, 0.05);
   transition: all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
-.login-page .login-container .login-form .form-login .input-group input:focus + .border {
+
+.login-page .login-container .login-form .form-login .input-group input:focus+.border {
   transform: scaleX(1);
 }
+
 .login-page .login-container .login-form .form-login .input-group .cbi-input-password {
   position: relative;
   margin-bottom: 2rem;
 }
+
 .login-page .login-container .login-form .form-login .input-group.user-icon::before {
   content: "\e971";
 }
+
 .login-page .login-container .login-form .form-login .input-group.pass-icon::before {
   content: "\e910";
 }
+
 .login-page .login-container .login-form .cbi-button-apply {
   width: 100% !important;
   min-height: 50px;
@@ -852,10 +992,12 @@ select[multiple="multiple"] {
   box-shadow: rgba(0, 0, 0, 0.1) 0 0 50px 0;
   transition: all 0.3s ease !important;
 }
+
 .login-page .login-container .login-form .cbi-button-apply:hover,
 .login-page .login-container .login-form .cbi-button-apply:focus {
   opacity: 0.9;
 }
+
 .login-page .login-container footer {
   position: absolute;
   bottom: 0;
@@ -870,14 +1012,17 @@ select[multiple="multiple"] {
   line-height: 1.6rem;
   font-size: 0.75rem;
 }
+
 .login-page .login-container footer .ftc {
   position: absolute;
   bottom: 30px;
   width: 100%;
 }
+
 .login-page .login-container footer .luci-link {
   display: block;
 }
+
 .main {
   position: relative;
   width: 100%;
@@ -886,6 +1031,7 @@ select[multiple="multiple"] {
   display: flex;
   flex-direction: row;
 }
+
 .main-left {
   width: 15rem;
   height: 100%;
@@ -897,10 +1043,12 @@ select[multiple="multiple"] {
   box-shadow: rgba(0, 0, 0, 0.75) 0px 0px 15px -5px;
   transition: all 0.2s;
 }
+
 .main-left .sidenav-header {
   padding: 1.5rem 0.5rem;
   text-align: center;
 }
+
 .main-left .sidenav-header .brand {
   display: block;
   margin: 0 2rem;
@@ -911,14 +1059,17 @@ select[multiple="multiple"] {
   text-align: center;
   cursor: default;
 }
+
 .main-left .sidenav-header .brand .logo {
   max-width: 100%;
   height: auto;
 }
+
 .main-left .nav {
   margin-top: 0.5rem;
 }
-.main-left .nav > li > a:first-child {
+
+.main-left .nav>li>a:first-child {
   display: block;
   position: relative;
   margin: 0.1rem 0.5rem;
@@ -929,26 +1080,32 @@ select[multiple="multiple"] {
   cursor: default;
   transition: all 0.2s;
 }
-.main-left .nav > li > a:first-child.active {
+
+.main-left .nav>li>a:first-child.active {
   color: #fff;
   background: var(--primary);
 }
-.main-left .nav > li > a:first-child.active::before {
+
+.main-left .nav>li>a:first-child.active::before {
   color: #fff !important;
 }
-.main-left .nav > li > a:first-child.active::after {
+
+.main-left .nav>li>a:first-child.active::after {
   transform: rotate(90deg);
   color: #fff !important;
 }
-.main-left .nav > li > a:first-child:hover {
+
+.main-left .nav>li>a:first-child:hover {
   cursor: pointer;
   color: #fff;
   background: var(--primary);
 }
-.main-left .nav > li > a:first-child:hover::before {
+
+.main-left .nav>li>a:first-child:hover::before {
   color: #fff !important;
 }
-.main-left .nav > li > a:first-child::before {
+
+.main-left .nav>li>a:first-child::before {
   position: absolute;
   left: 0.8rem;
   padding-top: 3px;
@@ -964,38 +1121,48 @@ select[multiple="multiple"] {
   color: var(--primary);
   transition: all 0.3s;
 }
-.main-left .nav > .slide > .menu::before {
+
+.main-left .nav>.slide>.menu::before {
   transition: transform 0.1s ease-in-out;
 }
-.main-left .nav > .slide > .menu.active::before {
+
+.main-left .nav>.slide>.menu.active::before {
   transition: transform 0.2s ease-in-out;
 }
+
 .main-left .nav li {
   padding: 0;
   cursor: pointer;
   user-select: none;
 }
+
 .main-left .nav li a {
   display: block;
   color: var(--menu-color);
 }
+
 .main-left .nav li.slide {
   padding: 0;
 }
+
 .main-left .nav li.slide ul {
   display: none;
   overflow: hidden;
 }
+
 .main-left .nav li.slide:hover {
   background: none;
 }
+
 .main-left .nav li.slide .slide-menu {
   margin: 0 0.5rem 0 2.5rem;
   padding: 0rem 0.5rem;
 }
+
 .main-left .nav li.slide .slide-menu.active {
   display: block;
 }
+
 .main-left .nav li.slide .slide-menu li {
   position: relative;
   margin: 0;
@@ -1003,6 +1170,7 @@ select[multiple="multiple"] {
   background: none;
   list-style: none;
 }
+
 .main-left .nav li.slide .slide-menu li a {
   padding: 0.5rem 0rem;
   text-decoration: none;
@@ -1010,6 +1178,7 @@ select[multiple="multiple"] {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
 .main-left .nav li.slide .slide-menu li::after {
   position: absolute;
   left: 0;
@@ -1020,19 +1189,24 @@ select[multiple="multiple"] {
   background-color: var(--primary);
   transition: all 0.2s;
 }
+
 .main-left .nav li.slide .slide-menu li:hover {
   background: none;
 }
+
 .main-left .nav li.slide .slide-menu li:hover::after {
   width: 100%;
 }
+
 .main-left .nav li.slide .slide-menu .active {
   background: none;
   color: var(--menu-color);
 }
+
 .main-left .nav li.slide .slide-menu .active a {
   color: var(--menu-color);
 }
+
 .main-left .nav li.slide .slide-menu .active::after {
   position: absolute;
   left: 0;
@@ -1043,12 +1217,15 @@ select[multiple="multiple"] {
   background-color: var(--primary);
   transition: all 0.2s;
 }
+
 .main-left .nav li.slide .slide-menu .active:hover {
   background: none;
 }
+
 .main-left .nav li.slide .slide-menu .active:hover::after {
   width: 100%;
 }
+
 .main-left .nav li .menu {
   display: block;
   position: relative;
@@ -1060,25 +1237,31 @@ select[multiple="multiple"] {
   cursor: default;
   transition: all 0.2s;
 }
+
 .main-left .nav li .menu.active {
   color: #fff;
   background: var(--primary);
 }
+
 .main-left .nav li .menu.active::before {
   color: #fff !important;
 }
+
 .main-left .nav li .menu.active::after {
   transform: rotate(90deg);
   color: #fff !important;
 }
+
 .main-left .nav li .menu:hover {
   cursor: pointer;
   color: #fff;
   background: var(--primary);
 }
+
 .main-left .nav li .menu:hover::before {
   color: #fff !important;
 }
+
 .main-left .nav li .menu::before {
   position: absolute;
   left: 0.8rem;
@@ -1095,6 +1278,7 @@ select[multiple="multiple"] {
   color: var(--primary);
   transition: all 0.3s;
 }
+
 .main-left .nav li .menu::after {
   position: absolute;
   right: 0.5rem;
@@ -1112,68 +1296,85 @@ select[multiple="multiple"] {
   text-rendering: auto;
   transition: all 0.3s;
 }
+
 .main-left .nav li .menu[data-title="Status"]:before {
   content: "\e906";
   color: var(--primary);
 }
+
 .main-left .nav li .menu[data-title="System"]:before {
   content: "\e90a";
   color: #fb6340;
 }
+
 .main-left .nav li .menu[data-title="Services"]:before {
   content: "\e909";
   color: #11cdef;
 }
+
 .main-left .nav li .menu[data-title="NAS"]:before {
   content: "\e90c";
   color: #f3a4b5;
 }
+
 .main-left .nav li .menu[data-title="VPN"]:before {
   content: "\e90b";
   color: #8965e0;
 }
+
 .main-left .nav li .menu[data-title="Network"]:before {
   content: "\e908";
   color: #8965e0;
 }
+
 .main-left .nav li .menu[data-title="Bandwidth_Monitor"]:before {
   content: "\e90d";
   color: #2dce89;
 }
+
 .main-left .nav li .menu[data-title="Docker"]:before {
   content: "\e911";
   color: #6699ff;
 }
+
 .main-left .nav li .menu[data-title="Statistics"]:before {
   content: "\e913";
   color: #8965e0;
 }
+
 .main-left .nav li .menu[data-title="Control"]:before {
   content: "\e912";
   color: var(--primary);
 }
+
 .main-left .nav li .menu[data-title="Asterisk"]:before {
   content: "\e914";
   color: #fb6340;
 }
+
 .main-left .nav li a[data-title="Log_out"]::before,
 .main-left .nav li .food[data-title="Log_out"]::before {
   content: "\e907";
   color: #adb5bd;
 }
-.main-left[style*="overflow: hidden"] > .nav > .slide > .menu::before {
+
+.main-left[style*="overflow: hidden"]>.nav>.slide>.menu::before {
   display: none;
 }
+
 .main-left::-webkit-scrollbar {
   width: 5px;
   height: 1px;
 }
+
 .main-left::-webkit-scrollbar-thumb {
   background-color: #f6f9fc;
 }
+
 .main-left::-webkit-scrollbar-track {
   background-color: #fff;
 }
+
 .main-right {
   height: 100%;
   flex-grow: 1;
@@ -1183,61 +1384,75 @@ select[multiple="multiple"] {
   flex-direction: column;
   transition: all 0.2s;
 }
-.main-right > #maincontent {
+
+.main-right>#maincontent {
   position: relative;
   z-index: 50;
   flex: 1;
   display: flex;
   flex-direction: column;
 }
-.main-right > #maincontent > .container {
+
+.main-right>#maincontent>.container {
   margin: 0 1.25rem 1rem 1.25rem;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
-.main-right > #maincontent .Dashboard {
+
+.main-right>#maincontent .Dashboard {
   color: var(--gray-dark) !important;
 }
-.main-right > #maincontent .Dashboard h3 {
+
+.main-right>#maincontent .Dashboard h3 {
   color: var(--gray-dark);
 }
-.main-right > #maincontent .Dashboard p {
+
+.main-right>#maincontent .Dashboard p {
   margin-top: 3px;
   margin-bottom: 3px;
 }
-.main-right > #maincontent .Dashboard hr {
+
+.main-right>#maincontent .Dashboard hr {
   border-top: 1px solid #000000;
 }
-.main-right > #maincontent .Dashboard .dashboard-bg {
+
+.main-right>#maincontent .Dashboard .dashboard-bg {
   background-color: #fff;
 }
-.main-right > #maincontent .Dashboard .table {
+
+.main-right>#maincontent .Dashboard .table {
   width: 100%;
 }
-.main-right > #maincontent .Dashboard .settings-info {
+
+.main-right>#maincontent .Dashboard .settings-info {
   padding-top: 1em;
   padding-bottom: 1em;
 }
-.main-right > #maincontent .Dashboard .settings-info p span:nth-child(2) {
+
+.main-right>#maincontent .Dashboard .settings-info p span:nth-child(2) {
   max-height: 18.5px;
   max-width: inherit;
   top: 4px;
 }
-.main-right > #maincontent .Dashboard .settings-info .label {
+
+.main-right>#maincontent .Dashboard .settings-info .label {
   font-size: 0.7rem;
   padding: 0.2rem 0.6rem;
 }
+
 header {
   position: relative;
   width: 100%;
   padding: 0;
   color: var(--header-color);
 }
+
 header.bg-primary {
   background-color: var(--primary) !important;
 }
+
 header::after {
   content: "";
   position: absolute;
@@ -1245,11 +1460,13 @@ header::after {
   height: 2rem;
   background-color: var(--primary) !important;
 }
+
 header .fill {
   padding: 0.8rem 0;
   display: flex;
   border-bottom: 0px solid rgba(255, 255, 255, 0.08) !important;
 }
+
 header .fill .container {
   width: 100%;
   height: 2rem;
@@ -1257,17 +1474,21 @@ header .fill .container {
   display: flex;
   align-items: center;
 }
+
 header .fill .container .flex1 {
   flex: 1;
 }
+
 header .fill .container .flex1 .showSide {
   display: none;
   font-size: 1.4rem;
   color: #fff;
 }
+
 header .fill .container .flex1 .showSide:hover {
   text-decoration: none;
 }
+
 header .fill .container .flex1 .brand {
   display: none;
   padding-left: 1rem;
@@ -1278,11 +1499,13 @@ header .fill .container .flex1 .brand {
   cursor: default;
   vertical-align: text-bottom;
 }
+
 header .fill .container .pull-right {
   margin-top: 0rem;
   float: right;
   display: flex;
 }
+
 header .fill .status span {
   display: inline-block;
   margin: 0 0.25rem;
@@ -1298,19 +1521,24 @@ header .fill .status span {
   transition: all 0.3s;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 2px 0 rgba(0, 0, 0, 0.12);
 }
+
 header .fill .status span:last-child {
   margin-right: 0;
 }
+
 header .fill .status span[data-indicator="poll-status"] {
   color: #fff;
 }
+
 header .fill .status span[data-style="active"] {
   background-color: var(--green);
 }
+
 header .fill .status span[data-style="inactive"] {
   color: #ffffff !important;
   background-color: #32325d;
 }
+
 footer {
   padding: 1rem;
   font-size: 0.875rem;
@@ -1319,17 +1547,20 @@ footer {
   white-space: nowrap;
   overflow: hidden;
 }
-footer > a {
+
+footer>a {
   color: #aaa;
   text-decoration: none;
 }
+
 #view {
   border-radius: 0.25rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
-#view > .spinning {
+
+#view>.spinning {
   position: fixed;
   top: 50%;
   left: 50%;
@@ -1339,34 +1570,43 @@ footer > a {
   background: #ffffff;
   box-shadow: 0 0 1rem 0 rgba(136, 152, 170, 0.15);
 }
-#view > div:first-child {
+
+#view>div:first-child {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
+
 #xhr_poll_status {
   display: flex;
   margin-left: 0.5rem;
 }
+
 #xhr_poll_status * {
   color: #fff;
 }
+
 .danger {
   background-color: var(--danger) !important;
 }
+
 .warning {
   background-color: var(--warning) !important;
 }
+
 .success {
   background-color: var(--success) !important;
 }
+
 .notice {
   background-color: var(--info) !important;
   color: #fff;
 }
+
 .error {
   color: var(--danger);
 }
+
 .alert,
 .alert-message {
   position: fixed;
@@ -1383,19 +1623,23 @@ footer > a {
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 2px 0 rgba(0, 0, 0, 0.12);
   text-shadow: none;
 }
+
 .alert.error,
 .alert-message.error {
   background-color: var(--warning);
 }
+
 .alert h4,
 .alert-message h4 {
   padding: 0.25rem 0rem;
   border-radius: 0.25rem;
 }
+
 .alert .btn,
 .alert-message .btn {
   height: auto;
 }
+
 .modal.alert-message {
   position: static;
   width: 90%;
@@ -1406,24 +1650,30 @@ footer > a {
   transform: none;
   margin: 5em auto;
 }
+
 .alert-message {
   transform: none;
   position: static;
 }
-.alert-message > h4 {
+
+.alert-message>h4 {
   font-size: 110%;
   font-weight: bold;
 }
-.alert-message > * {
+
+.alert-message>* {
   margin: 0.5rem 0;
 }
+
 .alert-message .btn {
   padding: 0.3rem 0.6rem;
 }
-#maincontent > .alert-message {
+
+#maincontent>.alert-message {
   position: fixed;
   transform: translate(-50%, -50%);
 }
+
 .container .alert,
 .container .alert-message {
   margin-left: 0;
@@ -1434,24 +1684,27 @@ footer > a {
   transform: translate(-50%, 0);
   width: 100%;
 }
-#mwan3-service-status > .alert-message {
+
+#mwan3-service-status>.alert-message {
   left: 0.5rem;
   transform: none;
 }
+
 .lg {
   margin: 0;
   padding: 0 !important;
 }
+
 .cbi-section,
 .cbi-section-error,
 #iptables,
 .Firewall form,
-#cbi-network > .cbi-section-node,
-#cbi-wireless > .cbi-section-node,
-#cbi-wireless > #wifi_assoclist_table,
+#cbi-network>.cbi-section-node,
+#cbi-wireless>.cbi-section-node,
+#cbi-wireless>#wifi_assoclist_table,
 [data-tab-title],
 [data-page^="admin-system-admin"]:not(.node-main-login) .cbi-map:not(#cbi-dropbear),
-[data-page="admin-system-opkg"] #maincontent > .container {
+[data-page="admin-system-opkg"] #maincontent>.container {
   font-family: inherit;
   font-weight: normal;
   font-style: normal;
@@ -1463,73 +1716,88 @@ footer > a {
   background-color: #fff;
   box-shadow: 0 0 1rem 0 rgba(136, 152, 170, 0.15);
 }
+
 .cbi-section:last-child,
 .cbi-section-error:last-child,
 #iptables:last-child,
 .Firewall form:last-child,
-#cbi-network > .cbi-section-node:last-child,
-#cbi-wireless > .cbi-section-node:last-child,
-#cbi-wireless > #wifi_assoclist_table:last-child,
+#cbi-network>.cbi-section-node:last-child,
+#cbi-wireless>.cbi-section-node:last-child,
+#cbi-wireless>#wifi_assoclist_table:last-child,
 [data-tab-title]:last-child,
 [data-page^="admin-system-admin"]:not(.node-main-login) .cbi-map:not(#cbi-dropbear):last-child,
-[data-page="admin-system-opkg"] #maincontent > .container:last-child {
+[data-page="admin-system-opkg"] #maincontent>.container:last-child {
   margin: 0;
   border: 0;
 }
+
 .cbi-modal .cbi-section,
 .cbi-section .cbi-section {
   padding: 0;
   box-shadow: none;
 }
+
 .cbi-modal .cbi-tabmenu {
   margin-left: 0;
 }
+
 .cbi-map {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
-.cbi-map > .cbi-tabmenu + div {
+
+.cbi-map>.cbi-tabmenu+div {
   margin-top: -0.4375rem;
 }
+
 .cbi-map-descr {
   font-size: small;
   line-height: 1.5;
   padding: 0 1.25rem;
 }
-.cbi-section > .cbi-section-descr {
+
+.cbi-section>.cbi-section-descr {
   padding-top: 1rem !important;
   padding-bottom: 1rem !important;
 }
-.cbi-section > .cbi-section-descr:empty {
+
+.cbi-section>.cbi-section-descr:empty {
   display: none;
 }
+
 .cbi-section-descr:not(:empty) {
   font-size: small;
   line-height: 1.5;
   padding: 0rem 1rem;
 }
+
 .cbi-section-descr:empty {
   display: none !important;
 }
-.cbi-map-descr + fieldset {
+
+.cbi-map-descr+fieldset {
   margin-top: 1rem;
 }
-.cbi-map-descr > abbr {
+
+.cbi-map-descr>abbr {
   cursor: help;
   text-decoration: underline;
 }
-.cbi-section > legend {
+
+.cbi-section>legend {
   display: none !important;
 }
-fieldset > fieldset,
-.cbi-section > .cbi-section {
+
+fieldset>fieldset,
+.cbi-section>.cbi-section {
   margin: 0;
   padding: 0;
   border: 0;
   box-shadow: none;
 }
-.cbi-section > h3:first-child,
+
+.cbi-section>h3:first-child,
 .panel-title {
   font-size: 1.1rem;
   line-height: 1;
@@ -1541,153 +1809,182 @@ fieldset > fieldset,
   color: #32325d;
   color: var(--gray-dark);
 }
-.cbi-section > h3:first-child,
-.cbi-section > h4:first-child,
-.cbi-section > p:first-child,
-[data-tab-title] > h3:first-child,
-[data-tab-title] > h4:first-child,
-[data-tab-title] > p:first-child {
+
+.cbi-section>h3:first-child,
+.cbi-section>h4:first-child,
+.cbi-section>p:first-child,
+[data-tab-title]>h3:first-child,
+[data-tab-title]>h4:first-child,
+[data-tab-title]>p:first-child {
   padding: 1rem 1.25rem;
 }
+
 .cbi-section p {
   padding: 1rem;
 }
+
 .cbi-tblsection {
   overflow-x: auto;
 }
+
 table {
   border-spacing: 0;
   border-collapse: collapse;
 }
+
 table,
 .table {
   overflow-y: hidden;
   width: 100%;
   font-size: 0.75rem;
 }
+
 .table .table-titles th {
   background-color: var(--lighter);
 }
-table > tbody > tr > td,
-table > tbody > tr > th,
-table > tfoot > tr > td,
-table > tfoot > tr > th,
-table > thead > tr > td,
-table > thead > tr > th,
-.table > .tbody > .tr > .td,
-.table > .tbody > .tr > .th,
-.table > .tfoot > .tr > .td,
-.table > .tfoot > .tr > .th,
-.table > .thead > .tr > .td,
-.table > .thead > .tr > .th,
-.table > .tr > .td.cbi-value-field,
-.table > .tr > .th.cbi-section-table-cell {
+
+table>tbody>tr>td,
+table>tbody>tr>th,
+table>tfoot>tr>td,
+table>tfoot>tr>th,
+table>thead>tr>td,
+table>thead>tr>th,
+.table>.tbody>.tr>.td,
+.table>.tbody>.tr>.th,
+.table>.tfoot>.tr>.td,
+.table>.tfoot>.tr>.th,
+.table>.thead>.tr>.td,
+.table>.thead>.tr>.th,
+.table>.tr>.td.cbi-value-field,
+.table>.tr>.th.cbi-section-table-cell {
   padding: 0.5rem;
 }
-.container > .cbi-section:first-of-type > .table[width="100%"] > .tr > .td {
+
+.container>.cbi-section:first-of-type>.table[width="100%"]>.tr>.td {
   padding: 0.6rem;
 }
+
 .cbi-section-table-cell {
   line-height: 1.1;
   align-self: flex-end;
   flex: 1 1 auto;
 }
-body:not([data-page="admin-dashboard"]) tr > td,
-body:not([data-page="admin-dashboard"]) tr > th,
-body:not([data-page="admin-dashboard"]) .tr > .td,
-body:not([data-page="admin-dashboard"]) .tr > .th,
+
+body:not([data-page="admin-dashboard"]) tr>td,
+body:not([data-page="admin-dashboard"]) tr>th,
+body:not([data-page="admin-dashboard"]) .tr>.td,
+body:not([data-page="admin-dashboard"]) .tr>.th,
 body:not([data-page="admin-dashboard"]) .cbi-section-table-row::before,
-body:not([data-page="admin-dashboard"]) #cbi-wireless > #wifi_assoclist_table > .tr:nth-child(2) {
+body:not([data-page="admin-dashboard"]) #cbi-wireless>#wifi_assoclist_table>.tr:nth-child(2) {
   border-top: thin solid #ddd;
   padding: 1.1em 1.25rem;
 }
+
 #cbi-wireless .td,
-.table[width="100%"] > .tr:first-child > .td,
-[data-page="admin-network-diagnostics"] .tr > .td,
-.tr.table-titles > .th,
-.tr.cbi-section-table-titles > .th {
+.table[width="100%"]>.tr:first-child>.td,
+[data-page="admin-network-diagnostics"] .tr>.td,
+.tr.table-titles>.th,
+.tr.cbi-section-table-titles>.th {
   border-top: 0 !important;
   background-color: #f6f9fc;
   padding: 1.1em 1.25rem;
   line-height: 1.3rem;
 }
-#cbi-network .tr:first-child > .td {
+
+#cbi-network .tr:first-child>.td {
   border-top: 0;
 }
-.table[width="100%"] > .tr:first-child > .td {
+
+.table[width="100%"]>.tr:first-child>.td {
   margin: auto 0;
 }
+
 .cbi-section-table-row {
   margin-bottom: 1rem;
   text-align: center !important;
   background: #f4f4f4;
 }
+
 .cbi-section-table-row:last-child {
   margin-bottom: 0;
 }
-.cbi-section-table-row > .cbi-value-field .cbi-dropdown,
-.cbi-section-table-row > .cbi-value-field .cbi-input-select,
-.cbi-section-table-row > .cbi-value-field .cbi-input-text,
-.cbi-section-table-row > .cbi-value-field .cbi-input-password {
+
+.cbi-section-table-row>.cbi-value-field .cbi-dropdown,
+.cbi-section-table-row>.cbi-value-field .cbi-input-select,
+.cbi-section-table-row>.cbi-value-field .cbi-input-text,
+.cbi-section-table-row>.cbi-value-field .cbi-input-password {
   width: 100%;
 }
-.cbi-section-table-row > .cbi-value-field .cbi-input-text,
-.cbi-section-table-row > .cbi-value-field .cbi-input-password {
+
+.cbi-section-table-row>.cbi-value-field .cbi-input-text,
+.cbi-section-table-row>.cbi-value-field .cbi-input-password {
   min-width: 80px;
 }
-.cbi-section-table-row > .cbi-value-field [data-dynlist] > input,
-.cbi-section-table-row > .cbi-value-field input.cbi-input-password {
+
+.cbi-section-table-row>.cbi-value-field [data-dynlist]>input,
+.cbi-section-table-row>.cbi-value-field input.cbi-input-password {
   width: calc(100% - 1.5rem);
 }
+
 .cbi-section-table-row .td {
   text-align: center !important;
 }
+
 .cbi-section-table-row .td .cbi-checkbox input[type="checkbox"] {
   margin: 0;
 }
+
 .control-group {
   display: inline-flex;
   width: 100%;
   flex-wrap: wrap;
   gap: 1rem;
 }
+
 .control-group input {
   border-right-width: 0;
   margin-right: 0;
 }
-.control-group input + button {
+
+.control-group input+button {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
   margin-left: 0;
   border-left-width: 0;
 }
+
 .control-group:has(> input:first-child + .cbi-button) {
   gap: 0 !important;
 }
+
 .control-group:has(> input:first-child + .cbi-button) input {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   width: 15.5rem;
   min-width: 15.5rem;
 }
-.control-group > * {
+
+.control-group>* {
   vertical-align: middle;
 }
-div > table > tbody > tr:nth-of-type(2n),
-div > .table > .tr:nth-of-type(2n) {
+
+div>table>tbody>tr:nth-of-type(2n),
+div>.table>.tr:nth-of-type(2n) {
   background-color: #f9f9f9;
 }
+
 /* fix multiple table */
 table table,
 .table .table,
 .cbi-value-field table,
 .cbi-value-field .table,
-td > table > tbody > tr > td,
-.td > .table > .tbody > .tr > .td,
-.cbi-value-field > table > tbody > tr > td,
-.cbi-value-field > .table > .tbody > .tr > .td {
+td>table>tbody>tr>td,
+.td>.table>.tbody>.tr>.td,
+.cbi-value-field>table>tbody>tr>td,
+.cbi-value-field>.table>.tbody>.tr>.td {
   border: 0;
 }
+
 /* button style */
 .btn,
 .cbi-button,
@@ -1714,9 +2011,11 @@ td > table > tbody > tr > td,
   -ms-touch-action: manipulation;
   touch-action: manipulation;
 }
+
 .btn:not(button) ul:not(.dropdown) li {
   padding: 0;
 }
+
 .cbi-button-up,
 .cbi-button-down {
   display: inline-block;
@@ -1727,12 +2026,15 @@ td > table > tbody > tr > td,
   background: url(../icon/arrow.svg) no-repeat center;
   background-size: 12px 20px;
 }
+
 .cbi-button-up {
   transform: scaleY(-1);
 }
+
 .cbi-button:not(select) {
   appearance: none !important;
 }
+
 .btn:hover,
 .btn:focus,
 .btn:active,
@@ -1742,12 +2044,13 @@ td > table > tbody > tr > td,
 .item:hover::after,
 .item:focus::after,
 .item:active::after,
-.cbi-page-actions .cbi-button-apply + .cbi-button-save:hover,
-.cbi-page-actions .cbi-button-apply + .cbi-button-save:focus,
-.cbi-page-actions .cbi-button-apply + .cbi-button-save:active {
+.cbi-page-actions .cbi-button-apply+.cbi-button-save:hover,
+.cbi-page-actions .cbi-button-apply+.cbi-button-save:focus,
+.cbi-page-actions .cbi-button-apply+.cbi-button-save:active {
   text-decoration: none;
   outline: 0;
 }
+
 .btn:hover,
 .btn:focus,
 .cbi-button:hover,
@@ -1756,18 +2059,22 @@ td > table > tbody > tr > td,
 .item:focus::after {
   box-shadow: 0 3px 9px rgba(50, 50, 9, 0), 3px 4px 8px rgba(94, 114, 228, 0.1);
 }
+
 .btn:active,
 .cbi-button:active,
 .item:active::after {
   box-shadow: 0 3px 9px rgba(50, 50, 9, 0), 3px 4px 8px rgba(94, 114, 228, 0.1);
 }
+
 .cbi-button-up:hover,
 .cbi-button-up:focus {
   box-shadow: 0 3px 9px rgba(50, 50, 9, 0), 3px 4px 8px rgba(94, 114, 228, 0.1);
 }
+
 .cbi-button-up:active {
   box-shadow: 0 3px 9px rgba(50, 50, 9, 0), 3px 4px 8px rgba(94, 114, 228, 0.1);
 }
+
 .btn:disabled,
 .cbi-button:disabled {
   cursor: not-allowed;
@@ -1775,6 +2082,7 @@ td > table > tbody > tr > td,
   opacity: 0.5;
   box-shadow: none;
 }
+
 /* gray */
 .alert-message [class="btn"],
 .modal div[class="btn"],
@@ -1790,10 +2098,11 @@ td > table > tbody > tr > td,
   border: thin solid #8898aa;
   background-color: #8898aa;
 }
+
 /* dark blue */
 .btn.primary,
 .cbi-page-actions .cbi-button-save,
-.cbi-page-actions .cbi-button-apply + .cbi-button-save,
+.cbi-page-actions .cbi-button-apply+.cbi-button-save,
 .cbi-button-add,
 .cbi-button-save,
 .cbi-button-positive,
@@ -1809,6 +2118,7 @@ td > table > tbody > tr > td,
   background-color: #5e72e4;
   background-color: var(--primary);
 }
+
 /* light blue */
 .cbi-page-actions .cbi-button-apply,
 .cbi-section-actions .cbi-button-edit,
@@ -1827,9 +2137,10 @@ td > table > tbody > tr > td,
   background-color: #5e72e4;
   background-color: var(--primary);
 }
+
 /* red */
 .btn.danger,
-.cbi-section-remove > .cbi-button,
+.cbi-section-remove>.cbi-button,
 .cbi-button-remove,
 .cbi-button-reset,
 .cbi-button-negative,
@@ -1844,6 +2155,7 @@ td > table > tbody > tr > td,
   background-color: #f5365c;
   background-color: var(--red);
 }
+
 /* yellow */
 .btn[value="Dismiss"],
 .cbi-button[value="Terminate"],
@@ -1857,6 +2169,7 @@ td > table > tbody > tr > td,
   border: thin solid #eea236;
   background-color: #f0ad4e;
 }
+
 /* green */
 .cbi-button-success,
 .cbi-button-download {
@@ -1865,12 +2178,15 @@ td > table > tbody > tr > td,
   border: thin solid #4cae4c;
   background-color: #5cb85c;
 }
+
 .cbi-page-actions .cbi-button-link:first-child {
   float: left;
 }
+
 .cbi-page-actions .cbi-dropdown .open {
   color: var(--white);
 }
+
 .cbi-page-actions .cbi-dropdown .more {
   display: block;
   width: 1px;
@@ -1879,15 +2195,18 @@ td > table > tbody > tr > td,
   text-indent: 5000px;
   background-color: var(--white);
 }
+
 .a-to-btn {
   text-decoration: none;
 }
+
 .cbi-value-field .cbi-button-add {
   font-weight: bold;
   padding: 1px 6px;
   display: inline-block;
   align-items: center;
 }
+
 .tabs {
   padding: 0 1rem;
   background-color: #FFFFFF;
@@ -1896,16 +2215,20 @@ td > table > tbody > tr > td,
   white-space: nowrap;
   overflow-x: auto;
 }
+
 .tabs::-webkit-scrollbar {
   width: 1px;
   height: 5px;
 }
+
 .tabs::-webkit-scrollbar-thumb {
   background-color: #f6f9fc;
 }
+
 .tabs::-webkit-scrollbar-track {
   background-color: #fff;
 }
+
 .tabs li[class~="active"],
 .tabs li:hover {
   cursor: pointer;
@@ -1917,11 +2240,13 @@ td > table > tbody > tr > td,
   margin-bottom: 0;
   border-radius: 0;
 }
+
 .tabs li[class~="active"] a,
 .tabs li:hover a {
   color: #5e72e4;
   color: var(--primary);
 }
+
 .tabs li {
   font-size: 0.875rem;
   display: inline-block;
@@ -1930,31 +2255,38 @@ td > table > tbody > tr > td,
   margin: 0;
   transition: all 0.2s;
 }
+
 .tabs li a {
   text-decoration: none;
   color: #404040;
   padding: 0.5rem 0.8rem;
 }
+
 .tabs li:hover {
   border-bottom: 0.18751rem solid #5e72e4;
   border-bottom: 0.18751rem solid var(--primary);
 }
+
 .cbi-tabmenu {
   color: white;
   padding: 0.5rem 1rem 0 1rem;
   white-space: nowrap;
   overflow-x: auto;
 }
+
 .cbi-tabmenu::-webkit-scrollbar {
   width: 1px;
   height: 5px;
 }
+
 .cbi-tabmenu::-webkit-scrollbar-thumb {
   background-color: #f6f9fc;
 }
+
 .cbi-tabmenu::-webkit-scrollbar-track {
   background-color: #fff;
 }
+
 .cbi-tabmenu li {
   background: #dce3e9;
   display: inline-block;
@@ -1966,11 +2298,13 @@ td > table > tbody > tr > td,
   margin: 0 0.2rem;
   position: relative;
 }
+
 .cbi-tabmenu li a {
   text-decoration: none;
   color: #404040;
   padding: 0.5rem 0.8rem;
 }
+
 .cbi-tabmenu li:hover {
   cursor: pointer;
   border-bottom: 0.18751rem solid #5e72e4;
@@ -1980,9 +2314,11 @@ td > table > tbody > tr > td,
   background-color: #e4e9ee;
   margin-bottom: 0;
 }
+
 .cbi-tabmenu li:hover a {
   color: #525f7f;
 }
+
 .cbi-tabmenu li[class~="cbi-tab"] {
   border-bottom: 0.18751rem solid #5e72e4;
   border-bottom: 0.18751rem solid var(--primary);
@@ -1991,33 +2327,41 @@ td > table > tbody > tr > td,
   background-color: #e4e9ee;
   margin-bottom: 0;
 }
+
 .cbi-tabmenu li[class~="cbi-tab"] a {
   color: #5e72e4;
   color: var(--primary);
 }
+
 .cbi-tab-descr {
   padding: 0 1.25rem;
 }
+
 .cbi-section-node {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
-.cbi-section-node > [id^="cbi-config-"] {
+
+.cbi-section-node>[id^="cbi-config-"] {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
-.cbi-section-node > [id^="cbi-config-"]:first-child {
+
+.cbi-section-node>[id^="cbi-config-"]:first-child {
   padding-top: 1rem;
 }
-.cbi-section-node > [id^="cbi-config-"]:last-child {
+
+.cbi-section-node>[id^="cbi-config-"]:last-child {
   padding-bottom: 1rem;
 }
+
 .cbi-section .cbi-section-remove:nth-of-type(2n),
-.container > .cbi-section .cbi-section-node:nth-of-type(2n) {
+.container>.cbi-section .cbi-section-node:nth-of-type(2n) {
   background-color: #f9f9f9;
 }
+
 [data-tab-title] {
   overflow: hidden;
   height: 0;
@@ -2026,10 +2370,12 @@ td > table > tbody > tr > td,
   padding: 1rem 0;
   display: none !important;
 }
+
 [data-tab-title] p {
   margin-left: 1rem;
   margin-bottom: 1rem;
 }
+
 [data-tab-active="true"] {
   overflow: visible;
   height: auto;
@@ -2038,29 +2384,36 @@ td > table > tbody > tr > td,
   transition: opacity 0.25s ease-in;
   margin: inherit !important;
 }
+
 .cbi-section[id] .cbi-section-remove:nth-of-type(4n+3),
 .cbi-section[id] .cbi-section-node:nth-of-type(4n+4) {
   background-color: #f9f9f9;
 }
+
 .cbi-section-node-tabbed {
   margin-top: 0;
   border: 0 solid #d4d4d4;
   border-radius: 0.25rem;
 }
-.cbi-section-node-tabbed > div {
+
+.cbi-section-node-tabbed>div {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
-.cbi-tabcontainer > .cbi-value:nth-of-type(2n) {
+
+.cbi-tabcontainer>.cbi-value:nth-of-type(2n) {
   background-color: #f9f9f9;
 }
+
 .cbi-value-field {
   display: table-cell;
 }
-.cbi-value-field div + br {
+
+.cbi-value-field div+br {
   display: none;
 }
+
 .cbi-value-description {
   line-height: 1.25;
   display: table-cell;
@@ -2068,13 +2421,16 @@ td > table > tbody > tr > td,
   opacity: 0.5;
   font-size: 0.75rem;
 }
+
 .cbi-value-description abbr {
   color: #32325d;
   color: var(--gray-dark);
 }
+
 .cbi-value-description:empty {
   display: none;
 }
+
 .cbi-value-title {
   display: table-cell;
   float: left;
@@ -2083,19 +2439,23 @@ td > table > tbody > tr > td,
   text-align: right;
   word-wrap: break-word;
 }
+
 .cbi-value {
   display: inline-block;
   width: 100%;
   padding: 0 1rem;
   line-height: 2.4rem;
 }
+
 .cbi-value ul {
   line-height: 1.25;
 }
+
 .cbi-value-field.cbi-dropdown-open .cbi-dropdown {
   border-color: var(--primary);
   box-shadow: 0 3px 9px rgba(50, 50, 9, 0), 3px 4px 8px rgba(94, 114, 228, 0.1);
 }
+
 .cbi-value-field .cbi-dropdown,
 .cbi-value-field .cbi-input-select,
 .cbi-value input[type="text"],
@@ -2103,23 +2463,29 @@ td > table > tbody > tr > td,
 .cbi-value textarea {
   min-width: 18rem;
 }
+
 #cbi-firewall-zone .cbi-input-select,
 #cbi-network-switch_vlan .cbi-input-select {
   min-width: 11rem;
 }
+
 #cbi-network-switch_vlan .cbi-input-text {
   max-width: 3rem;
 }
+
 .cbi-input-file {
   appearance: auto !important;
 }
+
 .cbi-input-file::-webkit-file-upload-button {
   display: inline-block !important;
 }
+
 .cbi-input-invalid {
   color: #f5365c !important;
   border-color: #f5365c !important;
 }
+
 .cbi-section-error {
   font-weight: bold;
   line-height: 1.42857143;
@@ -2129,13 +2495,16 @@ td > table > tbody > tr > td,
   border-radius: 3px;
   background-color: #fce6e6;
 }
+
 .cbi-section-error ul {
   margin: 0 0 0 20px;
 }
+
 .cbi-section-error ul li {
   font-weight: bold;
   color: #f5365c;
 }
+
 .td[data-title]::before {
   font-weight: bold;
   display: none;
@@ -2144,9 +2513,11 @@ td > table > tbody > tr > td,
   text-align: left;
   white-space: nowrap;
 }
+
 .tr.placeholder .td[data-title]::before {
   display: none;
 }
+
 .tr[data-title]::before,
 .tr.cbi-section-table-titles.named::before {
   font-weight: bold;
@@ -2161,45 +2532,56 @@ td > table > tbody > tr > td,
   word-wrap: break-word;
   background-color: #f6f9fc;
 }
+
 .cbi-rowstyle-1 {
   background-color: #f9f9f9;
 }
+
 .cbi-rowstyle-2 {
   background-color: #eee;
 }
+
 .cbi-rowstyle-2 .cbi-button-up,
 .cbi-rowstyle-2 .cbi-button-down,
 body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   background-color: #fff !important;
 }
+
 .cbi-section-table .cbi-section-table-titles .cbi-section-table-cell {
   width: auto !important;
 }
+
 .td.cbi-section-actions {
   text-align: right !important;
   vertical-align: middle;
 }
-.td.cbi-section-actions > * {
+
+.td.cbi-section-actions>* {
   display: inline-flex;
   gap: 1rem;
 }
-.td.cbi-section-actions > * > *,
-.td.cbi-section-actions > * > form > * {
+
+.td.cbi-section-actions>*>*,
+.td.cbi-section-actions>*>form>* {
   display: flex;
   align-items: center;
 }
-.td.cbi-section-actions > * > form {
+
+.td.cbi-section-actions>*>form {
   display: inline-flex;
   margin: 0;
 }
+
 .td .cbi-checkbox {
   justify-content: center;
 }
+
 .cbi-checkbox {
   display: flex;
   align-items: center;
   height: 2.5rem;
 }
+
 /* lists */
 .cbi-dynlist {
   line-height: 1.3;
@@ -2208,7 +2590,8 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   cursor: text;
   gap: 0.875rem;
 }
-.cbi-dynlist > .item {
+
+.cbi-dynlist>.item {
   display: inline-flex;
   flex-wrap: nowrap;
   position: relative;
@@ -2217,7 +2600,8 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   color: #8898aa;
   outline: 0;
 }
-.cbi-dynlist > .item::after {
+
+.cbi-dynlist>.item::after {
   content: "\00D7";
   pointer-events: auto;
   display: flex;
@@ -2238,7 +2622,8 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   box-shadow: none;
   box-sizing: border-box;
 }
-.cbi-dynlist > .item > span {
+
+.cbi-dynlist>.item>span {
   display: block;
   padding: 0.5rem 0.75rem;
   min-width: 15.5rem;
@@ -2259,14 +2644,16 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   box-sizing: border-box;
   transition: box-shadow 0.15s ease;
 }
-.cbi-dynlist > .add-item {
+
+.cbi-dynlist>.add-item {
   display: inline-flex;
   align-items: center;
   width: 100%;
   min-width: 15.5rem;
   flex-wrap: nowrap;
 }
-.cbi-dynlist > .add-item input {
+
+.cbi-dynlist>.add-item input {
   display: block;
   padding: 0.5rem 0.75rem;
   box-sizing: border-box;
@@ -2280,12 +2667,13 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   color: #8898aa;
   border: 1px solid #dee2e6;
   border-radius: 0.25rem 0 0 0.25rem;
-  border-right-width: 0;
+  border-right-width: 1px;
   outline: 0;
   background-image: none;
   box-shadow: none;
 }
-.cbi-dynlist > .add-item .cbi-button {
+
+.cbi-dynlist>.add-item .cbi-button {
   display: flex;
   width: auto !important;
   padding-left: 0.8rem;
@@ -2305,7 +2693,8 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
-.cbi-dynlist > .add-item .cbi-button-add {
+
+.cbi-dynlist>.add-item .cbi-button-add {
   width: 2.5rem !important;
   padding: 0.5rem 0 !important;
   font-weight: normal;
@@ -2314,24 +2703,29 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   background-color: var(--primary);
   border: 1px solid var(--primary);
 }
-.cbi-dynlist > .add-item:not([ondrop]) > input {
+
+.cbi-dynlist>.add-item:not([ondrop])>input {
   overflow: hidden;
   min-width: 15.5rem;
   width: 15.5rem;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-.cbi-dynlist > .item.drag-over,
-.cbi-dynlist > .add-item:has(.drag-over) {
+
+.cbi-dynlist>.item.drag-over,
+.cbi-dynlist>.add-item:has(.drag-over) {
   border-top: 1px solid var(--red);
   margin-top: -1px;
 }
-.cbi-dynlist[name="sshkeys"] > .item {
+
+.cbi-dynlist[name="sshkeys"]>.item {
   max-width: none;
 }
-.cbi-dynlist > .cbi-dynlist > .add-item[ondrop] > input {
+
+.cbi-dynlist>.cbi-dynlist>.add-item[ondrop]>input {
   min-width: 13rem;
 }
+
 .cbi-dynlist,
 .cbi-dropdown {
   position: relative;
@@ -2339,19 +2733,23 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   padding-right: 0.25rem;
   min-height: 2.1875rem;
 }
+
 .cbi-dropdown {
   align-items: center;
 }
-.cbi-dropdown.btn > ul:not(.dropdown),
-.cbi-dropdown.cbi-button > ul:not(.dropdown) {
+
+.cbi-dropdown.btn>ul:not(.dropdown),
+.cbi-dropdown.cbi-button>ul:not(.dropdown) {
   margin: 0 0.75rem;
 }
+
 .cbi-dropdown[placeholder*="select"] {
   max-width: 25rem;
   height: auto;
   margin-top: -3px;
 }
-.cbi-dropdown > ul {
+
+.cbi-dropdown>ul {
   display: flex;
   overflow-x: hidden;
   overflow-y: auto;
@@ -2360,23 +2758,29 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   list-style: none;
   outline: 0;
 }
-.cbi-dropdown > ul.preview {
+
+.cbi-dropdown>ul.preview {
   display: none;
 }
+
 .cbi-dropdown.cbi-button-apply,
 .cbi-dropdown.cbi-button-action {
   padding: 0;
 }
-.cbi-button-apply > ul.preview {
+
+.cbi-button-apply>ul.preview {
   display: none;
 }
-.cbi-button-apply > ul.preview li {
+
+.cbi-button-apply>ul.preview li {
   color: #fff;
 }
-.cbi-button-apply > ul:first-child li {
+
+.cbi-button-apply>ul:first-child li {
   color: #fff;
 }
-.cbi-dropdown > .open {
+
+.cbi-dropdown>.open {
   display: flex;
   align-items: center;
   width: 1rem;
@@ -2392,11 +2796,13 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   mask-position: center;
   mask-mode: match-source;
 }
-.cbi-dropdown > .more,
-.cbi-dropdown > ul > li[placeholder] {
+
+.cbi-dropdown>.more,
+.cbi-dropdown>ul>li[placeholder] {
   display: none;
 }
-.cbi-dropdown > ul > li {
+
+.cbi-dropdown>ul>li {
   display: none;
   overflow: hidden;
   align-items: center;
@@ -2408,38 +2814,47 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-.cbi-dropdown > ul > li .hide-open {
+
+.cbi-dropdown>ul>li .hide-open {
   display: initial;
 }
-.cbi-dropdown > ul > li .hide-close {
+
+.cbi-dropdown>ul>li .hide-close {
   display: none;
 }
-.cbi-dropdown > ul > li[display]:not([display="0"]) {
+
+.cbi-dropdown>ul>li[display]:not([display="0"]) {
   border-left: thin solid #ccc;
 }
-.cbi-dropdown[empty] > ul {
+
+.cbi-dropdown[empty]>ul {
   max-width: 1px;
 }
-.cbi-dropdown > ul > li > form {
+
+.cbi-dropdown>ul>li>form {
   display: none;
   margin: 0;
   padding: 0;
   pointer-events: none;
 }
-.cbi-dropdown > ul > li img {
+
+.cbi-dropdown>ul>li img {
   margin-right: 0.25em;
   vertical-align: middle;
 }
-.cbi-dropdown > ul > li > form > input[type="checkbox"] {
+
+.cbi-dropdown>ul>li>form>input[type="checkbox"] {
   height: auto;
   margin: 0;
 }
-.cbi-dropdown > ul > li input[type="text"] {
+
+.cbi-dropdown>ul>li input[type="text"] {
   height: 2rem;
   min-width: 16rem;
   padding: 0 0.5rem;
 }
-.cbi-dropdown[open] > ul.dropdown {
+
+.cbi-dropdown[open]>ul.dropdown {
   position: absolute;
   z-index: 1100;
   display: block;
@@ -2456,66 +2871,82 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   margin-top: 0.25rem;
   left: 0;
 }
-.cbi-dropdown[open] > ul.dropdown li {
+
+.cbi-dropdown[open]>ul.dropdown li {
   color: #000;
 }
-.cbi-dropdown > ul > li[display],
-.cbi-dropdown[open] > ul.preview,
-.cbi-dropdown[open] > ul.dropdown > li,
-.cbi-dropdown[multiple] > ul > li > label,
-.cbi-dropdown[multiple][open] > ul.dropdown > li,
-.cbi-dropdown[multiple][more] > .more,
-.cbi-dropdown[multiple][empty] > .more {
+
+.cbi-dropdown>ul>li[display],
+.cbi-dropdown[open]>ul.preview,
+.cbi-dropdown[open]>ul.dropdown>li,
+.cbi-dropdown[multiple]>ul>li>label,
+.cbi-dropdown[multiple][open]>ul.dropdown>li,
+.cbi-dropdown[multiple][more]>.more,
+.cbi-dropdown[multiple][empty]>.more {
   display: flex;
   align-items: center;
   flex-grow: 1;
 }
-.cbi-dropdown[empty] > ul > li,
-.cbi-dropdown[optional][open] > ul.dropdown > li[placeholder],
-.cbi-dropdown[multiple][open] > ul.dropdown > li > form {
+
+.cbi-dropdown[empty]>ul>li,
+.cbi-dropdown[optional][open]>ul.dropdown>li[placeholder],
+.cbi-dropdown[multiple][open]>ul.dropdown>li>form {
   display: block;
 }
-.cbi-dropdown[open] > ul.dropdown > li .hide-open {
+
+.cbi-dropdown[open]>ul.dropdown>li .hide-open {
   display: none;
 }
-.cbi-dropdown[open] > ul.dropdown > li .hide-close {
+
+.cbi-dropdown[open]>ul.dropdown>li .hide-close {
   display: initial;
 }
-.cbi-dropdown[open] > ul.dropdown > li {
+
+.cbi-dropdown[open]>ul.dropdown>li {
   border-bottom: thin solid #ccc;
   padding: 0.5rem 0.75rem;
   cursor: pointer;
 }
-.cbi-dropdown[open] > ul.dropdown > li label {
+
+.cbi-dropdown[open]>ul.dropdown>li label {
   margin-left: 0.5rem;
 }
-.cbi-dropdown[open] > ul.dropdown > li[selected] {
+
+.cbi-dropdown[open]>ul.dropdown>li[selected] {
   background: #e4e9ee;
 }
-.cbi-dropdown[open] > ul.dropdown > li.focus {
+
+.cbi-dropdown[open]>ul.dropdown>li.focus {
   background: #e4e9ee;
   outline: none;
 }
-.cbi-dropdown[open] > ul.dropdown > li:last-child {
+
+.cbi-dropdown[open]>ul.dropdown>li:last-child {
   margin-bottom: 0;
   border-bottom: 0;
 }
-.cbi-dropdown[open] > ul.dropdown > li[unselectable] {
+
+.cbi-dropdown[open]>ul.dropdown>li[unselectable] {
   opacity: 0.7;
 }
-.cbi-dropdown[open] > ul.dropdown > li > input.create-item-input:first-child:last-child {
+
+.cbi-dropdown[open]>ul.dropdown>li>input.create-item-input:first-child:last-child {
   width: 100%;
 }
+
 .cbi-dropdown[disabled] {
   pointer-events: none;
   opacity: 0.6;
 }
+
 .cbi-dropdown .zonebadge {
   width: 100%;
 }
+
 .cbi-dropdown[open] .zonebadge {
   width: auto;
 }
+
 /* progressbar */
 .cbi-progressbar {
   position: relative;
@@ -2527,7 +2958,8 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   height: 1rem;
   overflow: hidden;
 }
-.cbi-progressbar > div {
+
+.cbi-progressbar>div {
   display: block;
   position: absolute;
   height: 100%;
@@ -2535,6 +2967,7 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   border-radius: 0.5rem;
   transition: width 0.3s;
 }
+
 .cbi-progressbar::after {
   content: attr(title);
   position: absolute;
@@ -2546,6 +2979,7 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   line-height: 1rem;
   z-index: 2;
 }
+
 #modal_overlay {
   position: fixed;
   z-index: 900;
@@ -2559,6 +2993,7 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   background: rgba(0, 0, 0, 0.7);
   -webkit-overflow-scrolling: touch;
 }
+
 .modal {
   display: flex;
   align-items: center;
@@ -2573,14 +3008,16 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   background: #fff;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 2px 0 rgba(0, 0, 0, 0.12);
 }
-.modal > * {
+
+.modal>* {
   line-height: normal;
   flex-basis: 100%;
   margin-bottom: 0.5em;
   max-width: 100%;
 }
-.modal > pre,
-.modal > textarea {
+
+.modal>pre,
+.modal>textarea {
   font-size: 1rem;
   font-size-adjust: 0.35;
   overflow: auto;
@@ -2593,12 +3030,14 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   border: 1px solid var(--lighter);
   transition: all 0.2s ease;
 }
-.modal > pre:focus,
-.modal > textarea:focus {
+
+.modal>pre:focus,
+.modal>textarea:focus {
   border: 1px solid var(--primary);
   box-shadow: 0 3px 9px rgba(50, 50, 9, 0), 3px 4px 8px rgba(94, 114, 228, 0.1);
 }
-.modal > h4 {
+
+.modal>h4 {
   display: block;
   flex-grow: 1;
   max-width: none;
@@ -2608,21 +3047,26 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.03);
   border-radius: 0.25rem 0 0 0.25rem;
 }
+
 .modal h5 {
   margin-top: 1rem;
   font-weight: 600;
 }
-.modal label > input[type="checkbox"] {
+
+.modal label>input[type="checkbox"] {
   top: 0;
 }
+
 .modal ul li {
   list-style-type: square;
   color: #808080;
 }
+
 .modal p {
   word-break: break-word;
   margin-top: 1rem;
 }
+
 .modal .label {
   font-size: 0.6rem;
   font-weight: normal;
@@ -2631,32 +3075,40 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
   cursor: default;
   border-radius: 0;
 }
+
 .modal .label.warning {
   background-color: #f0ad4e !important;
 }
+
 .modal .btn {
   padding: 0.45rem 0.8rem;
 }
+
 .modal.cbi-modal {
   max-width: 90%;
   max-height: none;
 }
+
 .modal .cbi-map {
   margin-bottom: 1rem;
 }
+
 body.modal-overlay-active {
   overflow: hidden;
   height: 100vh;
 }
+
 body.modal-overlay-active #modal_overlay {
   right: 0;
   left: 0;
   opacity: 1;
 }
+
 .spinning {
   position: relative;
   padding-left: 32px !important;
 }
+
 .spinning::before {
   position: absolute;
   top: 0;
@@ -2667,18 +3119,22 @@ body.modal-overlay-active #modal_overlay {
   background: url(/luci-static/resources/icons/loading.svg) no-repeat center;
   background-size: 16px;
 }
+
 /* luci */
 .hidden {
   display: none;
 }
+
 .left,
 .left::before {
   text-align: left !important;
 }
+
 .right,
 .right::before {
   text-align: right !important;
 }
+
 .button-row {
   display: flex;
   flex-direction: row;
@@ -2687,30 +3143,37 @@ body.modal-overlay-active #modal_overlay {
   justify-content: flex-end;
   margin-bottom: 0 !important;
 }
+
 .center,
 .center::before {
   text-align: center !important;
 }
+
 .top {
   align-self: flex-start !important;
   vertical-align: top !important;
 }
+
 .bottom {
   align-self: flex-end !important;
   vertical-align: bottom !important;
 }
+
 .inline {
   display: inline;
 }
+
 .cbi-page-actions {
   padding: 1rem;
   justify-content: flex-end;
   display: flex;
   gap: 1rem;
 }
-.cbi-page-actions > form[method="post"] {
+
+.cbi-page-actions>form[method="post"] {
   display: inline-block;
 }
+
 .th[data-type="button"],
 .td[data-type="button"],
 .th[data-type="fvalue"],
@@ -2718,6 +3181,7 @@ body.modal-overlay-active #modal_overlay {
   flex: 1 1 2em;
   text-align: center;
 }
+
 .ifacebadge {
   display: inline-flex;
   align-items: center;
@@ -2726,44 +3190,53 @@ body.modal-overlay-active #modal_overlay {
   background: #eee;
   border-radius: 4px;
 }
-td > .ifacebadge,
-.td > .ifacebadge {
+
+td>.ifacebadge,
+.td>.ifacebadge {
   font-size: 0.875rem;
   background-color: #f0f0f0;
 }
-.ifacebadge > em,
-.ifacebadge > img {
+
+.ifacebadge>em,
+.ifacebadge>img {
   display: inline-block;
   margin: 0 0.75rem;
 }
-.ifacebadge > img + img {
+
+.ifacebadge>img+img {
   margin: 0 0.2rem 0 0;
 }
+
 .network-status-table {
   display: flex;
   flex-wrap: wrap;
 }
+
 .network-status-table .ifacebox {
   flex-grow: 1;
   border-radius: 0.25rem;
   overflow: hidden;
   margin: 1rem;
 }
+
 .network-status-table .ifacebox-body {
   display: flex;
   flex-direction: column;
   height: 100%;
   gap: 0.5em;
 }
-.network-status-table .ifacebox-body > span {
+
+.network-status-table .ifacebox-body>span {
   flex: 10 10 auto;
 }
-.network-status-table .ifacebox-body > div {
+
+.network-status-table .ifacebox-body>div {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   height: 100%;
 }
+
 .network-status-table .ifacebox-body .ifacebadge {
   align-items: center;
   flex: 1 1 auto;
@@ -2771,11 +3244,13 @@ td > .ifacebadge,
   padding: 0.5em;
   background-color: #fff;
 }
-.network-status-table .ifacebox-body .ifacebadge > span {
+
+.network-status-table .ifacebox-body .ifacebadge>span {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
 /* textarea */
 .cbi-input-textarea {
   font-family: inherit;
@@ -2788,9 +3263,11 @@ td > .ifacebadge,
   border: 1px solid #dee2e6;
   min-width: 16rem;
 }
+
 #content_syslog {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.03);
 }
+
 #syslog {
   font-size: small;
   font-family: 'Google Sans';
@@ -2805,12 +3282,15 @@ td > .ifacebadge,
   border-radius: 0.25rem;
   background-color: #ffffff;
 }
+
 #syslog:focus {
   outline: 0;
 }
+
 #cbi-ddns #syslog {
   overflow: auto;
 }
+
 /* config changes */
 .uci-change-list {
   font-family: inherit;
@@ -2820,6 +3300,7 @@ td > .ifacebadge,
   flex-direction: column;
   flex-wrap: wrap;
 }
+
 .uci-change-list ins,
 .uci-change-legend-label ins {
   display: block;
@@ -2828,6 +3309,7 @@ td > .ifacebadge,
   border: thin solid #0f0;
   background-color: #cfc;
 }
+
 .uci-change-list del,
 .uci-change-legend-label del {
   font-style: normal;
@@ -2837,6 +3319,7 @@ td > .ifacebadge,
   border: thin solid #f00;
   background-color: #fcc;
 }
+
 .uci-change-list var,
 .uci-change-legend-label var {
   font-style: normal;
@@ -2846,6 +3329,7 @@ td > .ifacebadge,
   border: thin solid #ccc;
   background-color: #eee;
 }
+
 .uci-change-list var ins,
 .uci-change-list var del {
   font-style: normal;
@@ -2853,39 +3337,47 @@ td > .ifacebadge,
   white-space: pre;
   border: 0;
 }
+
 .uci-change-legend {
   padding: 5px;
 }
+
 .uci-change-legend-label {
   float: left;
   width: 150px;
 }
-.uci-change-legend-label > ins,
-.uci-change-legend-label > del,
-.uci-change-legend-label > var {
+
+.uci-change-legend-label>ins,
+.uci-change-legend-label>del,
+.uci-change-legend-label>var {
   display: block;
   float: left;
   width: 10px;
   height: 10px;
   margin-right: 4px;
 }
+
 .uci-change-legend-label var ins,
 .uci-change-legend-label var del {
   line-height: 0.4;
   border: 0;
 }
+
 .uci-change-list var,
 .uci-change-list del,
 .uci-change-list ins {
   padding: 0.5rem;
 }
+
 .uci-dialog .cbi-section {
   padding: 0.5rem;
 }
+
 .uci-dialog .cbi-section .uci-change-legend {
   line-height: 15px;
   padding: 10px 20px 0 20px;
 }
+
 .uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label {
   padding: 0;
   margin: 0;
@@ -2894,45 +3386,55 @@ td > .ifacebadge,
   display: inline-block;
   width: 25%;
 }
-.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label > ins,
-.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label > del {
+
+.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label>ins,
+.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label>del {
   width: 14px;
   height: 14px;
 }
-.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label > var {
+
+.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label>var {
   position: relative;
   width: 14px;
   height: 14px;
 }
-.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label > var ins,
-.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label > var del {
+
+.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label>var ins,
+.uci-dialog .cbi-section .uci-change-legend .uci-change-legend-label>var del {
   position: absolute;
   left: 2px;
   top: 2px;
   right: 2px;
   bottom: 2px;
 }
+
 .uci-dialog .cbi-section .uci-change-list {
   overflow: auto;
 }
-.uci-dialog .cbi-section .uci-change-list + .right .btn {
+
+.uci-dialog .cbi-section .uci-change-list+.right .btn {
   color: #333;
 }
-.uci-dialog .cbi-section .uci-change-list + .right .cbi-dropdown ul:not(.dropdown) li {
+
+.uci-dialog .cbi-section .uci-change-list+.right .cbi-dropdown ul:not(.dropdown) li {
   color: #fff;
 }
-.uci-dialog .cbi-section .uci-change-list + .right .cbi-button {
+
+.uci-dialog .cbi-section .uci-change-list+.right .cbi-button {
   padding: 0.45rem 0.8rem;
 }
+
 /* other fix */
 #iwsvg,
 #iwsvg2,
 #bwsvg {
   border: thin solid #d4d4d4 !important;
 }
+
 #iwsvg {
   border-top: 0 !important;
 }
+
 .ifacebox {
   line-height: 1.25;
   display: inline-flex;
@@ -2942,99 +3444,122 @@ td > .ifacebadge,
   min-width: 100px;
   background-color: #f9f9f9;
 }
+
 .ifacebox-head {
   padding: 0.25em;
   background: #eee;
 }
+
 .ifacebox-head.active {
   background: #5e72e4;
   background: var(--primary);
 }
+
 .ifacebox-head.active * {
   color: #fff;
   color: var(--white);
 }
+
 .ifacebox-body {
   padding: 0.875rem 1rem;
   line-height: 1.6em;
 }
+
 .cbi-image-button {
   margin-left: 0.5rem;
 }
+
 .zonebadge {
   display: inline-block;
   padding: 0.2rem 0.5rem;
   border-radius: 4px;
 }
+
 .zonebadge .ifacebadge {
   margin: 0.1rem 0.2rem;
   padding: 0.2rem 0.3rem;
   border: thin solid #6c6c6c;
 }
-.zonebadge > input[type="text"] {
+
+.zonebadge>input[type="text"] {
   min-width: 10rem;
   margin-top: 0.3rem;
   padding: 0.16rem 1rem;
 }
-.zonebadge > em,
-.zonebadge > strong {
+
+.zonebadge>em,
+.zonebadge>strong {
   display: inline-block;
   margin: 0 0.2rem;
 }
+
 .cbi-value-field .cbi-input-checkbox,
 .cbi-value-field .cbi-input-radio {
   margin-top: 0.1rem;
 }
-.cbi-value-field > ul > li {
+
+.cbi-value-field>ul>li {
   display: flex;
 }
-.cbi-value-field > ul > li > label {
+
+.cbi-value-field>ul>li>label {
   margin-top: 0.5rem;
 }
-.cbi-value-field > ul > li .ifacebadge {
+
+.cbi-value-field>ul>li .ifacebadge {
   margin-top: -0.5rem;
   margin-left: 0.4rem;
   background-color: #eee;
 }
-.cbi-section-table-row > .cbi-value-field .cbi-dropdown {
+
+.cbi-section-table-row>.cbi-value-field .cbi-dropdown {
   min-width: 3rem;
 }
+
 .cbi-section-create {
   display: inline-flex;
   align-items: center;
   padding: 0.875rem 1rem;
 }
-.cbi-section-create > div:first-child > input {
+
+.cbi-section-create>div:first-child>input {
   width: 100%;
   border-right: none;
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
 }
-.cbi-section-create > div:first-child + button {
+
+.cbi-section-create>div:first-child+button {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
+
 .cbi-section-remove {
   padding: 0.5rem 1rem;
 }
+
 div.cbi-value var,
 td.cbi-value-field var,
 .td.cbi-value-field var {
   font-style: italic;
   color: #0069d6;
 }
+
 .cbi-optionals {
   padding: 1rem 1rem 0 1rem;
   border-top: thin solid #ccc;
 }
+
 .cbi-dropdown-container {
   position: relative;
 }
+
 .cbi-tooltip-container,
 span[data-tooltip],
 span[data-tooltip] .label {
   cursor: help !important;
 }
+
 .cbi-tooltip {
   position: absolute;
   z-index: 1000;
@@ -3048,37 +3573,45 @@ span[data-tooltip] .label {
   transition: opacity 0.25s ease-in;
   transform: translate(-50%, 10%);
 }
+
 .cbi-tooltip-container:hover .cbi-tooltip:not(:empty) {
   left: auto;
   transition: opacity 0.25s ease-in;
   opacity: 1;
 }
+
 .zonebadge .cbi-tooltip {
   margin: -1.5rem 0 0 -0.5rem;
   padding: 0.25rem;
   background: inherit;
 }
+
 .zonebadge-empty {
   color: #404040;
   background: repeating-linear-gradient(45deg, rgba(204, 204, 204, 0.5), rgba(204, 204, 204, 0.5) 5px, rgba(255, 255, 255, 0.5) 5px, rgba(255, 255, 255, 0.5) 10px);
 }
+
 .zone-forwards {
   display: flex;
   min-width: 10rem;
 }
-.zone-forwards > * {
+
+.zone-forwards>* {
   flex: 1 1 45%;
 }
-.zone-forwards > span {
+
+.zone-forwards>span {
   flex-basis: 10%;
   padding: 0 0.25rem;
   text-align: center;
 }
+
 .zone-forwards .zone-src,
 .zone-forwards .zone-dest {
   display: flex;
   flex-direction: column;
 }
+
 .label {
   font-size: 0.875rem;
   font-weight: bold;
@@ -3091,20 +3624,24 @@ span[data-tooltip] .label {
   background-color: #bfbfbf;
   text-shadow: none;
 }
-label > input[type="checkbox"],
-label > input[type="radio"] {
+
+label>input[type="checkbox"],
+label>input[type="radio"] {
   position: relative;
   top: 0.4rem;
   right: 0.2rem;
   margin: 0;
   vertical-align: bottom;
 }
+
 label[data-index][data-depends] {
   padding-right: 2em;
 }
+
 .showSide {
   display: none;
 }
+
 .darkMask {
   position: fixed;
   z-index: 99;
@@ -3116,12 +3653,14 @@ label[data-index][data-depends] {
   background-color: rgba(0, 0, 0, 0.56);
   transition: all 0.2s;
 }
+
 .darkMask.active {
   display: block;
 }
+
 /* diagnostics */
-#diag-rc-output > pre,
-#command-rc-output > pre,
+#diag-rc-output>pre,
+#command-rc-output>pre,
 [data-page="admin-services-wol"] .notice code {
   font-size: 1.2rem;
   font-size-adjust: 0.35;
@@ -3135,37 +3674,46 @@ label[data-index][data-depends] {
   background-color: #101010;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 2px 0 rgba(0, 0, 0, 0.12);
 }
+
 input[name="ping"],
 input[name="traceroute"],
 input[name="nslookup"] {
   width: 80%;
 }
+
 .controls {
   gap: 0.5rem;
   margin: 0 1.25rem !important;
 }
-.controls > div {
+
+.controls>div {
   gap: 0.5rem;
 }
-.controls > * > .btn:not([aria-label$="page"]) {
+
+.controls>*>.btn:not([aria-label$="page"]) {
   flex-grow: initial !important;
   margin-top: 0.25rem;
 }
-.controls > #pager > .btn[aria-label$="page"] {
+
+.controls>#pager>.btn[aria-label$="page"] {
   font-size: 1.4rem;
   font-weight: bold;
 }
-.controls > * > label {
+
+.controls>*>label {
   margin-bottom: 0.2rem;
 }
+
 .td.version,
 .td.size {
   white-space: normal !important;
   word-break: break-word;
 }
-.cbi-tabmenu + .cbi-section {
+
+.cbi-tabmenu+.cbi-section {
   margin-top: 0;
 }
+
 .cbi-tab-disabled[data-errors]::after {
   position: absolute;
   top: -0.25rem;
@@ -3182,12 +3730,14 @@ input[name="nslookup"] {
   justify-content: center;
   font-size: 0.75em;
 }
+
 /* custom commands */
 .commands {
   display: grid !important;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 0.75rem;
 }
+
 .commandbox {
   padding: 0.5rem 1rem;
   gap: 0.5rem;
@@ -3196,6 +3746,7 @@ input[name="nslookup"] {
   background: #eee;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
 }
+
 .commandbox h3 {
   line-height: normal !important;
   overflow: hidden;
@@ -3203,9 +3754,11 @@ input[name="nslookup"] {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
 .commandbox div {
   left: auto !important;
 }
+
 .commandbox code {
   overflow: hidden;
   max-width: fit-content;
@@ -3213,17 +3766,21 @@ input[name="nslookup"] {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
 .commandbox code:hover {
   overflow-y: auto;
   max-height: 50px;
   white-space: normal;
 }
+
 .commandbox p:first-of-type {
   margin-top: -6px;
 }
+
 .commandbox p:nth-of-type(2) {
   margin-top: 2px;
 }
+
 #command-rc-output .alert-message {
   line-height: 1.42857143;
   position: absolute;
@@ -3235,27 +3792,33 @@ input[name="nslookup"] {
   word-break: break-word;
   opacity: 0;
 }
+
 @keyframes anim-fade-in {
   100% {
     opacity: 1;
   }
 }
+
 /* other fix */
 .fb-container .cbi-button {
   height: auto !important;
 }
+
 #cbi-usb_printer-printer em {
   display: block;
   padding: 1rem;
   text-align: center;
 }
+
 pre.command-output {
   padding: 1.5rem;
 }
+
 .alert-message.spinning,
 .modal.alert-message.spinning {
   position: relative;
 }
+
 .alert-message.spinning::before,
 .modal.alert-message.spinning::before {
   height: 16px;
@@ -3264,22 +3827,28 @@ pre.command-output {
   top: 2rem;
   left: 0.5rem;
 }
-.cbi-dropdown.cbi-button-positive > ul > li[display="0"] {
+
+.cbi-dropdown.cbi-button-positive>ul>li[display="0"] {
   color: #fff;
 }
-.cbi-dropdown[open] > ul.dropdown > li[selected] {
+
+.cbi-dropdown[open]>ul.dropdown>li[selected] {
   color: #000;
 }
+
 /* page fix */
 [data-page="admin-system-autoreboot"] #cbi-autoreboot {
   margin-top: 0;
 }
+
 [data-page="admin-system-system"] .control-group {
   gap: 0.875rem;
 }
+
 [data-page="admin-system-system"] .cbi-dynlist {
   margin: 0.25rem 0;
 }
+
 [data-page="admin-system-admin"] .cbi-map h2,
 [data-page="admin-system-admin-password"] .cbi-map h2,
 [data-page="admin-system-admin"] .cbi-map .cbi-map-descr,
@@ -3287,16 +3856,20 @@ pre.command-output {
   margin-left: 0;
   color: var(--gray-dark);
 }
+
 [data-page="admin-system-admin"] .cbi-section-node,
 [data-page="admin-system-admin-password"] .cbi-section-node {
   padding: 1rem 0;
 }
+
 [data-page="admin-system-admin-sshkeys"] .cbi-dynlist {
   margin-left: 1rem;
 }
-[data-page="admin-system-startup"] #view > div:first-child div[data-initialized="true"] {
+
+[data-page="admin-system-startup"] #view>div:first-child div[data-initialized="true"] {
   margin-top: -0.4375rem;
 }
+
 [data-page="admin-system-startup"] [data-tab-title] p {
   margin-left: 0;
   margin-bottom: 0;
@@ -3304,6 +3877,7 @@ pre.command-output {
   align-items: center;
   justify-content: center;
 }
+
 [data-page="admin-system-startup"] textarea {
   line-height: 1.25;
   overflow-y: auto;
@@ -3316,11 +3890,13 @@ pre.command-output {
   border-radius: 0.25rem;
   border: 1px solid #dee2e6;
 }
+
 [data-page="admin-system-startup"] textarea:focus-visible {
   outline: none;
   box-shadow: none;
   border: 1px solid var(--primary);
 }
+
 [data-page="admin-system-crontab"] #view p textarea {
   line-height: 1.25;
   overflow-y: hidden;
@@ -3336,46 +3912,57 @@ pre.command-output {
   border: 1px solid #dee2e6;
   transition: all 0.2s ease;
 }
+
 [data-page="admin-system-crontab"] #view p textarea:focus-visible {
   outline: none;
   box-shadow: none;
   border: 1px solid var(--primary);
 }
+
 [data-page="admin-system-crontabhelper"] .crontab-row .dropdown-container {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
 }
+
 [data-page="admin-system-crontabhelper"] .crontab-row .dropdown-container div {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
 }
+
 [data-page="admin-system-partexp-global"] .cbi-section {
   padding: 1rem 0;
 }
+
 [data-page="admin-system-attendedsysupgrade"] #view .cbi-button {
   margin-left: 0 !important;
   margin-top: 1rem !important;
 }
+
 [data-page="admin-system-attendedsysupgrade-configuration"] .cbi-map .cbi-map-descr {
   padding-bottom: 0;
 }
+
 [data-page="admin-system-flash"] .cbi-value {
   padding: 0 1rem;
 }
+
 [data-page="admin-system-flash"] .cbi-section .cbi-section {
   margin-top: 0;
 }
+
 [data-page="admin-system-flash"] .cbi-map-tabbed {
   border-radius: 0.25rem;
 }
+
 [data-page="admin-system-flash"] .cbi-section-node {
   padding-top: 0;
   padding-bottom: 0.5rem;
 }
+
 [data-page="admin-system-flash"] legend {
   font-size: 1.2rem;
   width: 100%;
@@ -3388,178 +3975,225 @@ pre.command-output {
   font-weight: bold;
   padding: 1rem 0 1rem 1rem;
 }
+
 [data-page="admin-system-flash"] .cbi-section-descr {
   font-weight: 600;
   padding: 1rem 0 1rem 1rem;
   color: #525f7f;
 }
+
 [data-page="admin-system-flash"] .cbi-page-actions {
   padding: 0rem 1rem 1rem 0rem;
 }
-[data-page="admin-system-flash"] .modal label > input[type="checkbox"] {
+
+[data-page="admin-system-flash"] .modal label>input[type="checkbox"] {
   top: -0.25rem;
 }
+
 [data-page="admin-system-flash"] .modal .btn {
   white-space: normal !important;
 }
-[data-page="admin-system-flash"] .modal label > input[type="checkbox"] {
+
+[data-page="admin-system-flash"] .modal label>input[type="checkbox"] {
   vertical-align: text-top;
   top: auto;
 }
+
 [data-page="admin-system-filetransfer"] #cbi-upload {
   margin-top: 0;
 }
+
 [data-page="admin-system-filetransfer"] .cbi-section-table {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.03);
 }
+
 [data-page="admin-system-fileassistant"] #upload-toggle {
   display: none !important;
 }
+
 [data-page="admin-system-fileassistant"] .fb-container .panel-title {
   padding: 0.5rem 0.75rem !important;
 }
+
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container {
   padding: 0.5rem;
 }
+
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container label.cbi-value-title {
   line-height: 1.5rem;
   padding: 0.5rem 0.75rem;
   width: 60px;
   text-align: left;
 }
+
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container div.cbi-value-field {
   width: 100%;
   display: block;
   padding-left: 60px;
 }
+
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container div#list-content table.cbi-section-table thead td.cbi-section-table-cell,
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container div#list-content table.cbi-section-table tbody td.cbi-section-table-cell {
   width: 232px;
 }
+
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container div#list-content tbody tr:nth-child(1) td.parent-icon strong {
   margin-left: 0 !important;
 }
+
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container div#list-content tbody td.cbi-value-field.file-icon strong,
 [data-page="admin-system-fileassistant"] .cbi-section.fb-container div#list-content tbody td.cbi-value-field.folder-icon strong {
   vertical-align: middle;
   margin-left: 5px;
 }
+
 [data-page="admin-system-fileassistant"] .fb-container .panel-container {
   border-bottom-color: #dee2e6;
   display: flex;
 }
+
 [data-page="admin-system-fileassistant"] .fb-container .panel-container .panel-title {
   flex: 1;
 }
+
 [data-page="admin-system-fileassistant"] .fb-container .upload-container {
   display: flex !important;
 }
+
 [data-page="admin-system-fileassistant"] .fb-container .upload-container .upload-file {
   flex: 1;
   margin-right: 0 !important;
 }
+
 [data-page="admin-system-opkg"] h2 {
   margin-left: 0;
   color: var(--gray-dark);
 }
+
 [data-page="admin-system-opkg"] input[name="filter_i18n"] {
   top: 2px;
   vertical-align: text-top;
 }
+
 [data-page="admin-system-opkg"] div.btn {
   line-height: 3;
   display: inline;
   padding: 0.3rem 0.6rem;
 }
-[data-page="admin-system-opkg"] #maincontent > .container {
+
+[data-page="admin-system-opkg"] #maincontent>.container {
   margin: 0 1.25rem 1rem 1.25rem;
   margin-bottom: 1rem;
 }
-[data-page="admin-system-package-manager"] .controls div:nth-child(5) > label {
+
+[data-page="admin-system-package-manager"] .controls div:nth-child(5)>label {
   margin-bottom: 5px;
 }
-[data-page="admin-system-package-manager"] .controls div:nth-child(5) > div label {
+
+[data-page="admin-system-package-manager"] .controls div:nth-child(5)>div label {
   margin-top: 1rem;
 }
-[data-page="admin-system-package-manager"] .controls div:nth-child(5) > div label input {
+
+[data-page="admin-system-package-manager"] .controls div:nth-child(5)>div label input {
   top: -2px;
   right: 0;
   vertical-align: middle;
 }
+
 [data-page="admin-system-reboot"] p {
   padding-left: 1.5rem;
 }
-[data-page="admin-system-reboot"] p > span {
+
+[data-page="admin-system-reboot"] p>span {
   position: relative;
   top: 0.1rem;
   left: 1rem;
 }
+
 [data-page="admin-system-reboot"] .cbi-button {
   background: #fb6340 !important;
   border-color: #fb6340 !important;
   margin-left: 0 !important;
 }
+
 [data-page="admin-system-reboot"] .cbi-button.cbi-button-action.important {
   align-self: flex-end;
 }
+
 /* applyreboot fix */
 #applyreboot-container {
   margin: 2rem;
 }
+
 #applyreboot-section {
   line-height: 300%;
   margin: 2rem;
 }
-[data-page="admin-system-poweroff"] .container h2 + br + p {
+
+[data-page="admin-system-poweroff"] .container h2+br+p {
   margin-bottom: 1rem;
   padding-left: 1.5rem;
 }
+
 [data-page="admin-system-poweroffdevice"] .container h2 {
   margin: 0;
 }
-[data-page="admin-system-poweroffdevice"] .container h2 + p {
+
+[data-page="admin-system-poweroffdevice"] .container h2+p {
   margin-bottom: 1rem;
   padding-left: 1.5rem;
 }
-[data-page="admin-system-poweroffdevice"] .container button + div {
+
+[data-page="admin-system-poweroffdevice"] .container button+div {
   display: none;
 }
+
 [data-page="admin-system-poweroffdevice"] .btn.cbi-button.cbi-button-negative {
   align-self: flex-end;
 }
+
 [data-page="admin-network-network"] .cbi-value-field .cbi-dynlist {
   padding: 0 !important;
 }
-[data-page="admin-network-network"] .td > .ifacebadge > .cbi-tooltip-container {
+
+[data-page="admin-network-network"] .td>.ifacebadge>.cbi-tooltip-container {
   display: flex;
 }
-[data-page="admin-network-network"] .td > .ifacebadge > .cbi-tooltip-container img {
+
+[data-page="admin-network-network"] .td>.ifacebadge>.cbi-tooltip-container img {
   vertical-align: middle;
 }
+
 [data-page="admin-network-network"] div[data-name="_gen_server_keypair"] .cbi-value-title,
 [data-page="admin-network-network"] div[data-name="_gen_peer_keypair"] .cbi-value-title,
 [data-page="admin-network-network"] div[data-name="_gen_psk"] .cbi-value-title {
   height: 2.4rem;
 }
-[data-page="admin-network-network"] #modal_overlay > .modal.cbi-modal > div > p > textarea {
+
+[data-page="admin-network-network"] #modal_overlay>.modal.cbi-modal>div>p>textarea {
   height: 20em !important;
   border: 1px solid #dee2e6 !important;
   border-radius: 4px;
 }
+
 [data-page="admin-network-dhcp"] .cbi-value {
   padding: 0;
 }
+
 [data-page="admin-network-dhcp"] [data-tab-active="true"] {
   padding: 1rem 1rem !important;
 }
+
 [data-page="admin-network-diagnostics"] .table {
   box-shadow: none;
 }
+
 [data-page="admin-network-diagnostics"] .cbi-section {
   padding: 1rem;
   font-family: monospace;
   background: #fff !important;
 }
+
 [data-page="admin-network-diagnostics"] textarea {
   background: transparent;
   border-radius: 0.25rem;
@@ -3567,10 +4201,12 @@ pre.command-output {
   border: 1px solid #dee2e6;
   padding: 0.5rem;
 }
+
 [data-page="admin-network-diagnostics"] .tr {
   display: flex;
   flex-direction: row;
 }
+
 [data-page="admin-network-diagnostics"] .tr .td {
   background-color: #fff !important;
   border-bottom: 1px solid #dee2e6 !important;
@@ -3579,12 +4215,14 @@ pre.command-output {
   align-items: center;
   flex: 1;
 }
+
 [data-page="admin-network-diagnostics"] .tr .td input {
   margin: 0 !important;
   border-right: none !important;
   border-bottom-right-radius: 0 !important;
   border-top-right-radius: 0 !important;
 }
+
 [data-page="admin-network-diagnostics"] .tr .td .cbi-dropdown,
 [data-page="admin-network-diagnostics"] .tr .td .cbi-button {
   height: 2.5rem;
@@ -3592,6 +4230,7 @@ pre.command-output {
   border-bottom-left-radius: 0 !important;
   border-top-left-radius: 0 !important;
 }
+
 [data-page="admin-network-diagnostics"] .tr .td .cbi-dropdown .more,
 [data-page="admin-network-diagnostics"] .tr .td .cbi-button .more {
   display: block;
@@ -3601,40 +4240,49 @@ pre.command-output {
   text-indent: 5000px;
   background-color: var(--white);
 }
+
 [data-page="admin-network-diagnostics"] .cbi-dropdown .open {
   color: var(--white);
 }
+
 [data-page="admin-network-firewall-custom"] #view p,
 [data-page="admin-status-routes"] #view p {
   padding: 0 1.25rem;
 }
+
 [data-page="admin-network-firewall-custom"] #view p textarea,
 [data-page="admin-status-routes"] #view p textarea {
   padding: 1rem;
   border-radius: 0.25rem;
 }
-[data-page="admin-network-firewall-custom"] #view > h3,
-[data-page="admin-status-routes"] #view > h3 {
+
+[data-page="admin-network-firewall-custom"] #view>h3,
+[data-page="admin-status-routes"] #view>h3 {
   border-radius: 0.25rem 0.25rem 0 0;
 }
-[data-page="admin-network-firewall-custom"] #view .cbi-tabmenu + div,
-[data-page="admin-status-routes"] #view .cbi-tabmenu + div {
+
+[data-page="admin-network-firewall-custom"] #view .cbi-tabmenu+div,
+[data-page="admin-status-routes"] #view .cbi-tabmenu+div {
   margin-top: -0.5rem;
 }
+
 .cbi-section.fade-in .cbi-title {
   position: relative;
 }
-.cbi-section.fade-in .cbi-title > div:last-child {
+
+.cbi-section.fade-in .cbi-title>div:last-child {
   position: absolute;
   right: 1.25rem;
   top: 0;
 }
-.cbi-section.fade-in .cbi-title > div:last-child span {
+
+.cbi-section.fade-in .cbi-title>div:last-child span {
   font-size: 0;
-  background: none!important;
+  background: none !important;
   color: #ced4da !important;
 }
-.cbi-section.fade-in .cbi-title > div:last-child span:after {
+
+.cbi-section.fade-in .cbi-title>div:last-child span:after {
   transition: all 0.3s;
   font-family: 'argon' !important;
   content: '\e90f';
@@ -3643,181 +4291,230 @@ pre.command-output {
   position: absolute;
   right: 0;
 }
-.cbi-section.fade-in .cbi-title > div:last-child span[data-style=inactive]:after {
+
+.cbi-section.fade-in .cbi-title>div:last-child span[data-style=inactive]:after {
   transform: rotate(90deg);
 }
-[data-page="admin-status"] #view > div:first-child,
-[data-page="admin-status-overview"] #view > div:first-child {
+
+[data-page="admin-status"] #view>div:first-child,
+[data-page="admin-status-overview"] #view>div:first-child {
   gap: 0 !important;
 }
+
 [data-page="admin-status-iptables"] .right {
   margin-bottom: 0 !important;
 }
+
 [data-page="admin-status-nftables"] .nft-chain-hook {
   padding: 0.5rem 1.25rem;
 }
+
 [data-page="admin-status-nftables"] .alert-message {
   opacity: 1;
 }
+
 [data-page="admin-status-nftables"] .alert-message.fade-out {
   opacity: 0;
 }
+
 [data-page="admin-services-nlbw-display"] .cbi-section[data-tab="export"] {
   padding: 1.5rem !important;
 }
-[data-page="admin-services-nlbw-display"] .cbi-section > .right {
+
+[data-page="admin-services-nlbw-display"] .cbi-section>.right {
   margin: 15px 15px 0px 0px;
 }
+
 [data-page="admin-services-ddns"] #syslog {
   overflow: auto;
   font-size: 12px !important;
 }
+
 [data-page="admin-services-ttyd"] .container {
   display: flex;
   flex-direction: column;
 }
+
 [data-page="admin-services-ttyd"] #view {
   flex: 1;
 }
+
 [data-page="admin-services-ttyd"] #view iframe {
   height: 100%;
 }
+
 #cbi-dockerd .cbi-section {
   box-sizing: border-box;
   padding: 16px;
 }
+
 #cbi-dockerd .cbi-section.cbi-tblsection {
   padding: 0;
 }
+
 #cbi-smartdns #service_status {
   padding: 16px;
 }
+
 #cbi-smartdns .cbi-section-node {
   padding: 16px;
 }
+
 #cbi-docker .cbi-section .cbi-section-node {
   box-sizing: border-box;
   padding: 16px;
 }
+
 [data-page="admin-services-npc"] div[id="cbid.npc.config.vkey"] {
   white-space: normal;
 }
+
 [data-page="admin-services-npc"] div[id="cbid.npc.config.vkey"] input[id="widget.cbid.npc.config.vkey"][type="password"] {
   margin-top: 0;
   margin-bottom: 0;
 }
+
 [data-page="admin-services-npc"] div[id="cbid.npc.config.vkey"] .cbi-button {
   margin: 0;
   border: none;
 }
-[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".server_addr"]:not([id="cbid.npc.config.server_addr"]) + br,
-[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".vkey"]:not([id="cbid.npc.config.vkey"]) + br,
-[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".protocol"]:not([id="cbid.npc.config.protocol"]) + br,
-[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".dns"]:not([id="cbid.npc.config.dns"]) + br {
+
+[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".server_addr"]:not([id="cbid.npc.config.server_addr"])+br,
+[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".vkey"]:not([id="cbid.npc.config.vkey"])+br,
+[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".protocol"]:not([id="cbid.npc.config.protocol"])+br,
+[data-page="admin-services-npc"] div[id^="cbid.npc."][id$=".dns"]:not([id="cbid.npc.config.dns"])+br {
   display: none;
 }
+
 [data-page="admin-services-npc"] div.cbi-value.nowrap {
   white-space: normal;
 }
+
 [data-page^="admin-services-openclash"] .oc {
   --bg-light: #fff;
   --bg-gray: #fff;
   border-radius: 8px;
 }
+
 [data-page^="admin-services-openclash"] .oc .developer-container {
   background: transparent;
 }
+
 [data-page^="admin-services-openclash"] .oc .announcement-card {
-  width: auto!important;
-  margin: 10px!important;
+  width: auto !important;
+  margin: 10px !important;
 }
-[data-page^="admin-services-openclash"] #cbi-openclash > fieldset {
+
+[data-page^="admin-services-openclash"] #cbi-openclash>fieldset {
   background: none;
   padding: 0;
 }
-[data-page^="admin-services-openclash"] #cbi-openclash > fieldset > table > tbody > tr > td {
+
+[data-page^="admin-services-openclash"] #cbi-openclash>fieldset>table>tbody>tr>td {
   border: none;
   padding: 0;
 }
-[data-page^="admin-services-openclash"] #cbi-openclash > fieldset .main-card {
+
+[data-page^="admin-services-openclash"] #cbi-openclash>fieldset .main-card {
   border: none;
   box-shadow: none;
   padding: 0 10px 10px 10px;
   background: transparent;
 }
-[data-page^="admin-services-openclash"] #cbi-openclash > fieldset .myip-main-card {
+
+[data-page^="admin-services-openclash"] #cbi-openclash>fieldset .myip-main-card {
   margin: 0;
   padding: 10px;
   border: none;
   background: transparent;
 }
-[data-page^="admin-services-openclash"] #cbi-openclash > fieldset .myip-main-card .myip-section-title {
+
+[data-page^="admin-services-openclash"] #cbi-openclash>fieldset .myip-main-card .myip-section-title {
   margin: 0;
   border-width: 1px;
 }
+
 [data-page^="admin-services-openclash"] .sub-card .card-title {
   margin-top: 5px;
 }
+
 [data-page^="admin-services-openclash"] .oc .sub-card:hover {
   transform: none;
 }
+
 [data-page^="admin-services-openclash"] .oc .myip-ip-item:hover,
 [data-page^="admin-services-openclash"] .oc .myip-check-item:hover {
   transform: none;
 }
+
 [data-page^="admin-services-openclash"] .oc .main-cards-container {
   margin: 0 !important;
   gap: 0 !important;
 }
+
 [data-page^="admin-services-openclash"] .oc .config-file-bottom {
   margin-bottom: 5px;
 }
+
 [data-page^="admin-services-openclash"] .oc .config-file-bottom .card-actions {
   margin-bottom: 2px !important;
 }
+
 [data-page^="admin-services-openclash"] .oc .card-content {
   align-items: center !important;
   justify-content: center !important;
 }
+
 [data-page^="admin-services-openclash"] .oc .card-controls {
   align-self: center;
 }
+
 [data-page^="admin-services-openclash"] .oc .core-main-controls {
   justify-content: center !important;
 }
+
 [data-page^="admin-services-openclash"] .oc .plugin-toggle-container {
   margin-left: inherit !important;
 }
+
 [data-page^="admin-services-openclash"] .oc .core-status-toggle {
   flex: 0 !important;
   min-width: auto !important;
 }
+
 [data-page^="admin-services-openclash"] .oc .config-upload-content {
   background: #fff !important;
 }
+
 [data-page^="admin-services-openclash"] .oc .subscription-info-container {
   background: transparent !important;
 }
-[data-page^="admin-services-openclash"] .cbi-tabmenu > li {
+
+[data-page^="admin-services-openclash"] .cbi-tabmenu>li {
   border-right: none !important;
   margin: 0 0.4rem 0 0 !important;
 }
-[data-page^="admin-services-openclash"] .cbi-tabmenu > li:last-child {
+
+[data-page^="admin-services-openclash"] .cbi-tabmenu>li:last-child {
   margin-right: 0 !important;
 }
+
 [data-page^="admin-services-openclash"] #tab-content .dom {
   padding: 0 1rem 1rem 1rem;
 }
+
 [data-page^="admin-services-openclash"] .cbi-input-file {
   padding: 0.2813rem;
   width: 15rem !important;
 }
+
 [data-page^="admin-services-openclash"] [id="container.openclash.config.debug"] fieldset {
   border: none !important;
   padding: 1rem !important;
 }
-[data-page^="admin-services-openclash"] #diag-rc-output > pre,
-[data-page^="admin-services-openclash"] #dns-rc-output > pre {
+
+[data-page^="admin-services-openclash"] #diag-rc-output>pre,
+[data-page^="admin-services-openclash"] #dns-rc-output>pre {
   font-size: 0.875rem;
   color: #8898aa;
   border: 1px solid #dee2e6;
@@ -3826,26 +4523,32 @@ pre.command-output {
   font-family: 'Google Sans' !important;
   box-shadow: none;
 }
-[data-page^="admin-services-openclash"] #debug-rc-output > textarea {
+
+[data-page^="admin-services-openclash"] #debug-rc-output>textarea {
   font-family: 'Google Sans' !important;
 }
+
 [data-page^="admin-services-openclash"] .CodeMirror {
   font-size: inherit;
   font-family: 'Google Sans' !important;
 }
+
 [data-page^="admin-services-openclash"] .cbi-button-up,
 [data-page^="admin-services-openclash"] .cbi-button-down {
   padding: 0.8rem 1.5rem;
   background-color: #f1f1f1;
   font-size: 0;
 }
+
 [data-page^="admin-services-openclash"] select#CORE_VERSION,
 [data-page^="admin-services-openclash"] select#RELEASE_BRANCH {
   width: auto;
 }
+
 [data-page="admin-vpn-passwall"] h4 {
   background: transparent;
 }
+
 [data-page^="admin-vpn-passwall2"] .tr,
 [data-page^="admin-services-passwall2"] .tr,
 [data-page^="admin-vpn-passwall2"] .td,
@@ -3865,30 +4568,37 @@ pre.command-output {
   contain: none !important;
   clip-path: none !important;
 }
+
 /* openvpn bug fix */
 .OpenVPN a {
   line-height: initial !important;
 }
+
 /* wireless overview */
-#cbi-wireless > #wifi_assoclist_table > .tr {
+#cbi-wireless>#wifi_assoclist_table>.tr {
   box-shadow: inset 1px -1px 0 #ddd, inset -1px -1px 0 #ddd;
 }
-#cbi-wireless > #wifi_assoclist_table > .tr.placeholder > .td {
+
+#cbi-wireless>#wifi_assoclist_table>.tr.placeholder>.td {
   right: 2rem;
   bottom: 2rem;
   left: 2rem;
   border-top: thin solid #ddd !important;
 }
-#cbi-wireless > #wifi_assoclist_table > .tr.table-titles {
+
+#cbi-wireless>#wifi_assoclist_table>.tr.table-titles {
   box-shadow: inset 1px 0 0 #ddd, inset -1px 0 0 #ddd;
 }
-#cbi-wireless > #wifi_assoclist_table > .tr.table-titles > .th {
+
+#cbi-wireless>#wifi_assoclist_table>.tr.table-titles>.th {
   border-bottom: thin solid #ddd;
   box-shadow: 0 -1px 0 0 #ddd;
 }
-#wifi_assoclist_table > .tr > .td[data-title="RX Rate / TX Rate"] {
+
+#wifi_assoclist_table>.tr>.td[data-title="RX Rate / TX Rate"] {
   width: 23rem;
 }
+
 #cbi-wireless,
 #cbi-wireless *,
 #wifi_assoclist_table,
@@ -3900,122 +4610,151 @@ pre.command-output {
   contain: none !important;
   clip-path: none !important;
 }
+
 #cbi-wireless,
 #wifi_assoclist_table {
   height: auto !important;
   min-height: 0 !important;
 }
+
 /* samba */
 #cbi-samba [data-tab="template"] .cbi-value-field {
   display: block;
 }
+
 #cbi-samba [data-tab="template"] .cbi-value-title {
   width: auto;
   padding-bottom: 0.6rem;
 }
+
 /* fix status */
-.node-status-overview > .main fieldset:nth-child(4) .td:nth-child(2),
-.node-status-processes > .main .table .tr .td:nth-child(3) {
+.node-status-overview>.main fieldset:nth-child(4) .td:nth-child(2),
+.node-status-processes>.main .table .tr .td:nth-child(3) {
   white-space: normal;
 }
+
 div[style*="display:grid;grid-template-columns:repeat"] {
   display: flex !important;
   justify-content: space-evenly !important;
   flex-wrap: wrap;
 }
+
 div[style*="display:grid;grid-template-columns:repeat"] .ifacebox {
   text-align: center;
   flex-basis: 100px;
 }
+
 div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body {
   font-size: 0.7rem;
   padding: 0.875rem;
 }
+
 div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body .cbi-tooltip-container {
   font-size: inherit !important;
 }
+
 /* firewall */
 #iptables {
   margin: 0;
 }
+
 .Firewall form {
   margin: 2rem 2rem 0 0;
   padding: 0;
   box-shadow: none;
 }
+
 #cbi-firewall-redirect table *,
 #cbi-network-switch_vlan table *,
 #cbi-firewall-zone table * {
   font-size: small;
 }
+
 #cbi-firewall-redirect table input[type="text"],
 #cbi-network-switch_vlan table input[type="text"],
 #cbi-firewall-zone table input[type="text"] {
   width: 5rem;
 }
+
 #cbi-firewall-redirect table select,
 #cbi-network-switch_vlan table select,
 #cbi-firewall-zone table select {
   min-width: 3.5rem;
 }
+
 #cbi-network-switch_vlan .th,
 #cbi-network-switch_vlan .td {
   flex-basis: 12%;
 }
+
 #cbi-network-switch_vlan .table {
   display: block;
 }
+
 #cbi-network-switch_vlan .td {
   width: 100%;
 }
+
 #cbi-firewall-zone .table {
   display: block;
 }
+
 #cbi-firewall-zone .td {
   width: 100%;
 }
+
 [data-page^="admin-system-commands"] .panel-title,
 [data-page^="command-cfg"] .mobile-hide,
 [data-page^="command-cfg"] .showSide {
   display: none;
 }
+
 #mwan3-service-status {
   display: flex;
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
 }
-#mwan3-service-status > .alert-message {
+
+#mwan3-service-status>.alert-message {
   position: static;
   transform: none;
 }
+
 /* responsive */
 @media all and (-ms-high-contrast: none) {
-  .main > .main-left > .nav > .slide > .menu::before {
+  .main>.main-left>.nav>.slide>.menu::before {
     top: 30.25%;
   }
-  .main > .main-left > .nav > li:last-child::before {
+
+  .main>.main-left>.nav>li:last-child::before {
     top: 20%;
   }
+
   .showSide::before {
     top: -12px;
   }
 }
+
 @media screen and (max-width: 1600px) {
-  header > .fill > .container > #logo {
+  header>.fill>.container>#logo {
     margin: 0 2.5rem 0 0.5rem;
   }
+
   .main-left {
     width: calc(0% + 13rem);
   }
+
   .btn:not(button),
   .label {
     padding: 0.5rem 0.75rem;
   }
+
   .cbi-value-title {
     width: 15rem;
     padding-right: 0.6rem;
   }
+
   .cbi-value-field .cbi-dropdown,
   .cbi-value-field .cbi-input-select,
   .cbi-value input[type="text"],
@@ -4023,144 +4762,180 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
   .cbi-value textarea {
     min-width: 18rem;
   }
+
   #cbi-firewall-zone .cbi-input-select {
     min-width: 9rem;
   }
+
   .cbi-input-textarea {
     font-size: small;
   }
-  .node-admin-status > .main fieldset li > a {
+
+  .node-admin-status>.main fieldset li>a {
     padding: 0.3rem 0.6rem;
   }
 }
+
 @media screen and (max-width: 1366px) {
-  header > .fill > .container {
+  header>.fill>.container {
     cursor: default;
   }
+
   .main-left {
     width: calc(0% + 13rem);
   }
-  .tabs > li > a,
-  .cbi-tabmenu > li > a {
+
+  .tabs>li>a,
+  .cbi-tabmenu>li>a {
     padding: 0.2rem 0.8rem;
   }
+
   .panel-title {
     font-size: 1.1rem;
     padding-bottom: 1rem;
   }
+
   table {
     width: 100% !important;
   }
+
   .table .cbi-input-text {
     width: 100%;
   }
+
   .cbi-value-field .cbi-dropdown,
   .cbi-value-field .cbi-input-select,
   .cbi-value input[type="text"],
   .cbi-value input[type="password"] {
     min-width: 16rem;
   }
+
   #cbi-firewall-zone .cbi-input-select {
     min-width: 5.5rem;
   }
-  .main > .main-left > .nav > li,
-  .main > .main-left > .nav > li > a,
-  .main .main-left .nav > li > a:first-child,
-  .main > .main-left > .nav > .slide > .menu,
-  .main > .main-left > .nav > li > [data-title="Log_out"] {
+
+  .main>.main-left>.nav>li,
+  .main>.main-left>.nav>li>a,
+  .main .main-left .nav>li>a:first-child,
+  .main>.main-left>.nav>.slide>.menu,
+  .main>.main-left>.nav>li>[data-title="Log_out"] {
     font-size: 0.9rem;
   }
-  .main > .main-left > .nav > .slide > .slide-menu > li > a {
+
+  .main>.main-left>.nav>.slide>.slide-menu>li>a {
     font-size: 0.875rem;
   }
+
   #modal_overlay {
     top: 0rem;
   }
+
   [data-page="admin-network-firewall-forwards"] .table:not(.cbi-section-table) {
     display: block;
   }
+
   [data-page="admin-network-firewall-forwards"] .table:not(.cbi-section-table),
   [data-page="admin-network-firewall-rules"] .table:not(.cbi-section-table),
   [data-page="admin-network-hosts"] .table,
   [data-page="admin-network-routes"] .table {
     overflow-y: visible;
   }
+
   .btn:not(button),
   .cbi-button {
     font-size: 0.875rem;
   }
 }
+
 @media screen and (max-width: 1152px) {
-  header > .fill > .container > #logo {
+  header>.fill>.container>#logo {
     display: none;
   }
-  header > .fill > .container > .brand {
+
+  header>.fill>.container>.brand {
     position: relative;
   }
+
   html,
   .main {
     overflow-y: visible;
   }
-  .main > .loading > span {
+
+  .main>.loading>span {
     top: 25%;
   }
+
   .main-left {
     width: calc(0% + 13rem);
   }
+
   body:not(.logged-in) .showSide {
     visibility: hidden;
     width: 0;
     margin: 0;
   }
-  .node-main-login > .main .cbi-value-title {
+
+  .node-main-login>.main .cbi-value-title {
     text-align: left;
   }
+
   .cbi-value-title {
     width: 12rem;
     padding-right: 1rem;
   }
+
   .cbi-value-field .cbi-dropdown,
   .cbi-value-field .cbi-input-select,
   .cbi-value input[type="text"] {
     width: 16rem;
     min-width: 16rem;
   }
+
   .cbi-value input[name^="pw"],
   .cbi-value input[data-update="change"]:nth-child(2) {
     width: 13rem !important;
     min-width: 13rem;
   }
-  #diag-rc-output > pre,
-  #command-rc-output > pre,
+
+  #diag-rc-output>pre,
+  #command-rc-output>pre,
   [data-page="admin-services-wol"] .notice code {
     font-size: 1rem;
   }
+
   .table {
     display: block;
   }
+
   .Interfaces .table {
     overflow-x: hidden;
   }
+
   #packages.table {
     display: grid;
   }
+
   .tr {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
   }
-  .Overview .table[width="100%"] > .tr {
+
+  .Overview .table[width="100%"]>.tr {
     flex-wrap: nowrap;
   }
+
   .tr.placeholder {
     border-bottom: thin solid #ddd;
   }
-  .tr.placeholder > .td,
-  #cbi-firewall .tr > .td,
-  #cbi-network .tr:nth-child(2) > .td,
-  .cbi-section #wifi_assoclist_table .tr > .td {
+
+  .tr.placeholder>.td,
+  #cbi-firewall .tr>.td,
+  #cbi-network .tr:nth-child(2)>.td,
+  .cbi-section #wifi_assoclist_table .tr>.td {
     border-top: 0;
   }
+
   .th,
   .td {
     display: inline-block;
@@ -4169,20 +4944,24 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     text-overflow: ellipsis;
     word-wrap: break-word;
   }
+
   .td select,
   .td input[type="text"] {
     width: 100%;
     word-wrap: normal;
   }
-  .td [data-dynlist] > input,
+
+  .td [data-dynlist]>input,
   .td input.cbi-input-password {
     width: calc(100% - 1.5rem);
   }
+
   .td[data-type="button"],
   .td[data-type="fvalue"] {
     flex: 1 1 12.5%;
     text-align: left;
   }
+
   .th.cbi-value-field,
   .td.cbi-value-field,
   .th.cbi-section-table-cell,
@@ -4190,6 +4969,7 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     flex-basis: auto;
     padding-top: 1rem;
   }
+
   .cbi-section-table-row {
     display: flex;
     flex-direction: row;
@@ -4197,6 +4977,7 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     justify-content: space-between;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 2px 0 rgba(0, 0, 0, 0.12);
   }
+
   .td.cbi-value-field,
   .cbi-section-table-cell {
     display: inline-block;
@@ -4204,14 +4985,17 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     flex-basis: 50%;
     text-align: center;
   }
+
   .td.cbi-section-actions {
     vertical-align: bottom;
   }
+
   .tr.table-titles,
   .tr.cbi-section-table-titles,
   .tr.cbi-section-table-descr {
     display: none;
   }
+
   .tr[data-title]::before,
   .tr.cbi-section-table-titles.named::before {
     font-size: 0.9rem;
@@ -4220,70 +5004,87 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     border-bottom: thin solid rgba(0, 0, 0, 0.26);
     background: #e9ecef;
   }
+
   .td[data-title],
   [data-page^="admin-status-realtime"] .td[id] {
     text-align: left;
   }
+
   .td[data-title]::before {
     display: block;
   }
-  .cbi-button + .cbi-button {
+
+  .cbi-button+.cbi-button {
     margin-left: 0;
   }
-  .td.cbi-section-actions > * > *,
-  .td.cbi-section-actions > * > form > * {
+
+  .td.cbi-section-actions>*>*,
+  .td.cbi-section-actions>*>form>* {
     margin: 2.1px 3px;
   }
+
   .Firewall form {
     position: static !important;
     margin: 0 0 2rem 0;
     padding: 2rem;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 2px 0 rgba(0, 0, 0, 0.12);
   }
+
   .Firewall form input {
     width: 100% !important;
     margin: 0;
     margin-top: 1rem;
   }
+
   .Firewall .center,
   .Firewall .center::before {
     text-align: left !important;
   }
+
   .btn:not(button),
   .cbi-button {
     font-size: 0.875rem;
   }
 }
+
 @media screen and (max-width: 768px) {
   body {
     font-size: 0.875rem;
   }
+
   .cbi-progressbar::after {
     font-size: 0.6rem;
   }
+
   .main-left {
     position: fixed;
     z-index: 100;
     width: 0;
   }
+
   .main-left.active {
     width: 13rem;
   }
+
   .main-right {
     width: 100%;
   }
+
   .main-right.active {
     overflow-y: hidden;
   }
+
   .darkMask.active {
     display: block;
   }
+
   .showSide {
     padding: 0.1rem;
     position: relative;
     z-index: 99;
     display: inline-block !important;
   }
+
   .showSide::before {
     font-family: 'argon' !important;
     font-style: normal !important;
@@ -4296,53 +5097,67 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     content: "\e20e";
     font-size: 1.7rem;
   }
-  header > .fill > .container > .flex1 > .brand {
+
+  header>.fill>.container>.flex1>.brand {
     display: inline-block;
   }
-  .main > .main-left > .nav > .slide > .slide-menu > li > a {
+
+  .main>.main-left>.nav>.slide>.slide-menu>li>a {
     font-size: 0.875rem;
   }
 }
+
 @media screen and (max-width: 600px) {
   .mobile-hide {
     display: none;
   }
-  #maincontent > .container {
+
+  #maincontent>.container {
     margin: 0 1rem 1rem 1rem;
   }
+
   .cbi-value-title {
     text-align: left;
   }
+
   .cbi-dynlist p {
     padding: 0.5rem 1rem;
   }
+
   body {
     overflow-x: hidden;
   }
+
   .node-main-login .main .main-right #maincontent .container .cbi-map .cbi-section .cbi-section-node .cbi-value .cbi-value-field {
     width: 16rem;
   }
+
   .node-main-login footer {
     display: none;
   }
+
   .tabs::-webkit-scrollbar,
   .cbi-tabmenu::-webkit-scrollbar {
     width: 0px;
     height: 0px;
   }
+
   .cbi-value-field,
   .cbi-value-description {
     display: block !important;
     padding-left: 0 !important;
     padding-right: 0 !important;
   }
+
   [data-page="admin-system-admin-password"] .cbi-value-field {
     display: table-cell !important;
   }
+
   .modal.cbi-modal {
     max-width: 100%;
     max-height: none;
   }
+
   .modal {
     display: flex;
     align-items: center;
@@ -4357,31 +5172,39 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     background: #fff;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 2px 0 rgba(0, 0, 0, 0.12);
   }
-  .cbi-dropdown[open] > ul.dropdown {
+
+  .cbi-dropdown[open]>ul.dropdown {
     margin-bottom: 1rem;
   }
+
   .login-page .login-container footer {
     display: none;
   }
 }
+
 @media screen and (max-width: 480px) {
   .mobile-hide {
     display: none;
   }
+
   div[style*="display:grid;grid-template-columns:repeat"] .ifacebox {
     flex-basis: 80px;
   }
+
   div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body {
     padding: 0.875rem 0.5rem;
     font-size: 0.6rem;
   }
+
   .login-page .login-container {
     margin-left: 0rem !important;
     width: 100%;
   }
+
   .login-page .login-container .login-form .form-login .input-group::before {
     color: #525461;
   }
+
   .login-page .login-container .login-form .form-login .input-group input {
     color: #525461;
     border-bottom: white 1px solid;
@@ -4389,22 +5212,27 @@ div[style*="display:grid;grid-template-columns:repeat"] .ifacebox .ifacebox-body
     border-radius: 0;
   }
 }
+
 @media screen and (min-width: 600px) {
   ::-webkit-scrollbar {
     width: 10px;
     height: 10px;
   }
+
   ::-webkit-scrollbar,
   ::-webkit-scrollbar-corner {
     background: transparent;
   }
+
   ::-webkit-scrollbar-thumb {
     background: var(--primary);
     border-radius: 10px;
   }
+
   ::-webkit-scrollbar-thumb:hover {
     background: var(--primary);
   }
+
   ::-webkit-scrollbar-thumb:active {
     background: var(--primary);
   }


### PR DESCRIPTION
网络-接口-高级设置-IPv6前缀过滤器，打开下拉框，自定义输入框右边显示不全
<img width="1010" height="513" alt="2026-07-18_143959" src="https://github.com/user-attachments/assets/c9f12b1f-22d7-4ebb-a2ca-c69ad540744a" />
解决办法是删除cascade.css文件的2283行(border-right-width: 0;)或者修改为大于0即可
<img width="1464" height="327" alt="2026-07-18_145004" src="https://github.com/user-attachments/assets/036ff2bb-2f67-40b9-8a15-265edad9966a" />
