### PR TITLE
fix(apk): avoid replacing uclient-fetch with wget-nossl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Argon Theme
-LUCI_DEPENDS:=+wget +jsonfilter
+LUCI_DEPENDS:=+USE_APK:wget-any +!USE_APK:wget +jsonfilter
 PKG_VERSION:=2.4.4
 PKG_RELEASE:=20260716
 


### PR DESCRIPTION
## Summary

- depend on `wget-any` for APK builds
- keep the existing `wget` dependency for opkg builds

## Root cause

On OpenWrt 25.12, `uclient-fetch` provides `wget-any`, while this package
currently requires the concrete `wget` capability. APK therefore installs
`wget-nossl`, whose higher alternatives priority replaces `/usr/bin/wget`.

OpenWrt's APK package manager uses the wget URL backend, so repository
downloads over HTTPS fail after that replacement.

## Compatibility

The previous unconditional switch to `wget-any` in #671 was reverted by #673
because older Lean/LEDE builds do not provide that virtual dependency.
Conditioning the dependency on `USE_APK` fixes current APK builds while
preserving the existing opkg dependency.

## Validation

- built with the OpenWrt snapshot x86/64 APK SDK and verified the final package
  depends on `libc`, `jsonfilter`, and `wget-any`
- built with the OpenWrt 23.05.5 x86/64 IPK SDK and verified the final package
  depends on `libc`, `wget`, and `jsonfilter`
- ran `git diff --check`

Fixes #681
Fixes #682

Related: openwrt/openwrt#24270
