### PR TITLE
fix(openclash): align CBI zebra row spacing

### DIFF
--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -4390,6 +4390,14 @@ pre.command-output {
   white-space: normal;
 }
 
+[data-page^="admin-services-openclash"] .cbi-section-node-tabbed > .cbi-tabcontainer {
+  gap: 0;
+}
+[data-page^="admin-services-openclash"] .cbi-section-node-tabbed > .cbi-tabcontainer > .cbi-value {
+  padding-top: 0.4375rem;
+  padding-bottom: 0.4375rem;
+}
+
 [data-page^="admin-services-openclash"] .oc {
   --bg-light: #fff;
   --bg-gray: #fff;

--- a/less/page-fix.less
+++ b/less/page-fix.less
@@ -712,6 +712,15 @@
 
 // Services - OpenClash
 [data-page^="admin-services-openclash"] {
+    .cbi-section-node-tabbed>.cbi-tabcontainer {
+        gap: 0;
+
+        >.cbi-value {
+            padding-top: 0.4375rem;
+            padding-bottom: 0.4375rem;
+        }
+    }
+
     .oc {
         --bg-light: #fff;
         --bg-gray: #fff;


### PR DESCRIPTION
## Summary

- remove the unpainted flex gap between traditional CBI rows on OpenClash pages
- redistribute the existing `0.875rem` spacing as `0.4375rem` top and bottom padding on each row
- update the compiled `cascade.css` alongside the Less source

## Root cause

Argon applies zebra striping to even `.cbi-value` rows while `.cbi-tabcontainer` uses a `0.875rem` flex gap and the rows have no vertical padding. The gap is painted by the parent rather than the striped row, so light rows appear taller and controls on shaded rows touch the background boundary even though the actual control spacing is uniform.

This change keeps the same effective 14 px spacing between adjacent row contents (`7 px + 7 px`) while moving that space inside the row backgrounds.

## Scope and impact

The override is limited to `[data-page^="admin-services-openclash"]` and reuses Argon's existing OpenClash-specific page-fix mechanism. It does not change LuCI templates, OpenClash markup, grid layout, or CBI behavior outside OpenClash.

## Validation

- compiled `less/cascade.less` successfully with Less 4.2.2
- passed `git diff --check`
- verified on an ImmortalWrt test router with Argon 2.4.3 and OpenClash 0.47.133
- checked the overwrite settings page at 1440 px and 720 px widths in light and dark modes
- confirmed a 0 px container gap, 7 px row padding on both edges, and a 7 px control offset from shaded row boundaries
- confirmed equal rendered heights for matching shaded and unshaded control types
