### PR TITLE
fix(openclash): normalize config switcher tab height

### DIFF
--- a/htdocs/luci-static/argon/css/cascade.css
+++ b/htdocs/luci-static/argon/css/cascade.css
@@ -4400,6 +4400,15 @@ pre.command-output {
   white-space: normal;
 }
 
+[data-page^="admin-services-openclash"] .tabs > #tool_label {
+  padding-top: 0;
+  padding-bottom: 0;
+  vertical-align: middle;
+}
+[data-page^="admin-services-openclash"] .tabs > #tool_label .tool_label_span {
+  display: inline-flex;
+  align-items: center;
+}
 [data-page^="admin-services-openclash"] .cbi-section-node-tabbed > .cbi-tabcontainer {
   gap: 0;
 }

--- a/less/page-fix.less
+++ b/less/page-fix.less
@@ -712,6 +712,18 @@
 
 // Services - OpenClash
 [data-page^="admin-services-openclash"] {
+    // Normalize the OpenClash config switcher and top-level tab bar height
+    .tabs>#tool_label {
+        padding-top: 0;
+        padding-bottom: 0;
+        vertical-align: middle;
+
+        .tool_label_span {
+            display: inline-flex;
+            align-items: center;
+        }
+    }
+
     .cbi-section-node-tabbed>.cbi-tabcontainer {
         gap: 0;
 


### PR DESCRIPTION
## 修改内容

- 在 Argon 的 OpenClash 专用适配区统一配置切换器与一级标签栏高度。
- 移除 `#tool_label` 继承的上下标签内边距，保留下拉框和“切换”按钮原有的 40px 高度。
- 使用 `inline-flex` 使配置名称、下拉框和按钮保持垂直居中。
- 同步更新 Less 源码及生成的 `cascade.css`。

## 问题原因

OpenClash 会将配置切换器 `li#tool_label` 插入一级 `.tabs` 标签栏。

Argon 的通用 `.tabs li` 规则提供上下各 14px 内边距；配置切换器内的下拉框和按钮高度为 40px。因此，含配置切换器的页面会将标签栏从约 50px 撑高至约 72px，在不同 OpenClash 页面之间切换时产生明显的纵向跳变。

本次修复仅作用于 OpenClash 页面中的 `#tool_label`，不修改全局标签栏或表单控件尺寸。

## 验证

- 已在私有 OpenWrt 测试环境完成实际部署和浏览器验证。
- 已检查含配置切换器与不含配置切换器的 OpenClash 一级页面：
  - 含切换器页面的 `.tabs`：72.4375px 降至 50px。
  - 不含切换器页面的 `.tabs`：保持 50px。
- 已检查桌面端与移动端宽度、浅色与深色模式、标签栏横向滚动、活动标签样式及控件可见性。
- 下拉框和切换按钮保持可用，未出现裁切、重叠或点击区域错位。
- 已执行 `git diff --check`。
